### PR TITLE
Add byte offsets to Token and AstNode

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -65,11 +65,15 @@ pub enum TokenKind {
 pub struct Token {
     pub kind: TokenKind,
     pub text: String,
+    pub byte_start: usize,
+    pub byte_end: usize,
 }
 
 pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
     let mut tokens = Vec::new();
     let chars: Vec<char> = input.chars().collect();
+    // Build a mapping from char index → byte offset in the original string.
+    let char_to_byte: Vec<usize> = input.char_indices().map(|(b, _)| b).collect();
     let len = chars.len();
     let mut i = 0;
 
@@ -106,7 +110,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 }
                 continue;
             } else {
-                tokens.push(Token { kind: TokenKind::Slash, text: "/".into() });
+                tokens.push(Token { kind: TokenKind::Slash, text: "/".into(), byte_start: char_to_byte[i], byte_end: char_to_byte[i] + 1 });
                 i += 1;
                 continue;
             }
@@ -115,23 +119,23 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         // 3. Multi-char operators
         if c == '!' && i + 1 < len {
             if chars[i + 1] == '=' {
-                tokens.push(Token { kind: TokenKind::NotEq, text: "!=".into() });
+                tokens.push(Token { kind: TokenKind::NotEq, text: "!=".into(), byte_start: char_to_byte[i], byte_end: char_to_byte[i + 1] + 1 });
                 i += 2;
                 continue;
             } else if chars[i + 1] == '~' {
-                tokens.push(Token { kind: TokenKind::NotTilde, text: "!~".into() });
+                tokens.push(Token { kind: TokenKind::NotTilde, text: "!~".into(), byte_start: char_to_byte[i], byte_end: char_to_byte[i + 1] + 1 });
                 i += 2;
                 continue;
             }
             return Err(format!("Unexpected character '!' at position {i}"));
         }
         if c == '<' && i + 1 < len && chars[i + 1] == '=' {
-            tokens.push(Token { kind: TokenKind::LtEq, text: "<=".into() });
+            tokens.push(Token { kind: TokenKind::LtEq, text: "<=".into(), byte_start: char_to_byte[i], byte_end: char_to_byte[i + 1] + 1 });
             i += 2;
             continue;
         }
         if c == '>' && i + 1 < len && chars[i + 1] == '=' {
-            tokens.push(Token { kind: TokenKind::GtEq, text: ">=".into() });
+            tokens.push(Token { kind: TokenKind::GtEq, text: ">=".into(), byte_start: char_to_byte[i], byte_end: char_to_byte[i + 1] + 1 });
             i += 2;
             continue;
         }
@@ -159,25 +163,31 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             _ => None,
         };
         if let Some(kind) = single {
-            tokens.push(Token { kind, text: c.to_string() });
+            tokens.push(Token { kind, text: c.to_string(), byte_start: char_to_byte[i], byte_end: char_to_byte[i] + c.len_utf8() });
             i += 1;
             continue;
         }
 
         // 5. $ variables
         if c == '$' {
-            if input[i..].starts_with("$this") && !is_ident_continue(chars.get(i + 5).copied()) {
-                tokens.push(Token { kind: TokenKind::DollarThis, text: "$this".into() });
+            if input[char_to_byte[i]..].starts_with("$this") && !is_ident_continue(chars.get(i + 5).copied()) {
+                let bs = char_to_byte[i];
+                let be = bs + "$this".len();
+                tokens.push(Token { kind: TokenKind::DollarThis, text: "$this".into(), byte_start: bs, byte_end: be });
                 i += 5;
                 continue;
             }
-            if input[i..].starts_with("$index") && !is_ident_continue(chars.get(i + 6).copied()) {
-                tokens.push(Token { kind: TokenKind::DollarIndex, text: "$index".into() });
+            if input[char_to_byte[i]..].starts_with("$index") && !is_ident_continue(chars.get(i + 6).copied()) {
+                let bs = char_to_byte[i];
+                let be = bs + "$index".len();
+                tokens.push(Token { kind: TokenKind::DollarIndex, text: "$index".into(), byte_start: bs, byte_end: be });
                 i += 6;
                 continue;
             }
-            if input[i..].starts_with("$total") && !is_ident_continue(chars.get(i + 6).copied()) {
-                tokens.push(Token { kind: TokenKind::DollarTotal, text: "$total".into() });
+            if input[char_to_byte[i]..].starts_with("$total") && !is_ident_continue(chars.get(i + 6).copied()) {
+                let bs = char_to_byte[i];
+                let be = bs + "$total".len();
+                tokens.push(Token { kind: TokenKind::DollarTotal, text: "$total".into(), byte_start: bs, byte_end: be });
                 i += 6;
                 continue;
             }
@@ -187,13 +197,15 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         // 6. DateTime/Time literals (starts with @)
         if c == '@' {
             let start = i;
+            let byte_start = char_to_byte[i];
             i += 1;
             if i < len && chars[i] == 'T' {
                 // Time literal: @T followed by TIMEFORMAT
                 i += 1;
                 i = scan_timeformat(&chars, i);
                 let text: String = chars[start..i].iter().collect();
-                tokens.push(Token { kind: TokenKind::Time, text });
+                let byte_end = if i < len { char_to_byte[i] } else { input.len() };
+                tokens.push(Token { kind: TokenKind::Time, text, byte_start, byte_end });
                 continue;
             }
             // DateTime literal: @YYYY(-MM(-DD(T TIMEFORMAT)?)?)?Z?
@@ -211,27 +223,33 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 i += 1;
             }
             let text: String = chars[start..i].iter().collect();
-            tokens.push(Token { kind: TokenKind::DateTime, text });
+            let byte_end = if i < len { char_to_byte[i] } else { input.len() };
+            tokens.push(Token { kind: TokenKind::DateTime, text, byte_start, byte_end });
             continue;
         }
 
         // 7. String literals (starts with ')
         if c == '\'' {
+            let byte_start = char_to_byte[i];
             let text = scan_quoted(&chars, &mut i, '\'')?;
-            tokens.push(Token { kind: TokenKind::String, text });
+            let byte_end = if i < len { char_to_byte[i] } else { input.len() };
+            tokens.push(Token { kind: TokenKind::String, text, byte_start, byte_end });
             continue;
         }
 
         // 8. Delimited identifiers (starts with `)
         if c == '`' {
+            let byte_start = char_to_byte[i];
             let text = scan_quoted(&chars, &mut i, '`')?;
-            tokens.push(Token { kind: TokenKind::DelimitedIdentifier, text });
+            let byte_end = if i < len { char_to_byte[i] } else { input.len() };
+            tokens.push(Token { kind: TokenKind::DelimitedIdentifier, text, byte_start, byte_end });
             continue;
         }
 
         // 9. Numbers
         if c.is_ascii_digit() {
             let start = i;
+            let byte_start = char_to_byte[i];
             while i < len && chars[i].is_ascii_digit() {
                 i += 1;
             }
@@ -243,17 +261,20 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 }
             }
             let text: String = chars[start..i].iter().collect();
-            tokens.push(Token { kind: TokenKind::Number, text });
+            let byte_end = if i < len { char_to_byte[i] } else { input.len() };
+            tokens.push(Token { kind: TokenKind::Number, text, byte_start, byte_end });
             continue;
         }
 
         // 10. Identifiers and keywords
         if is_ident_start(c) {
             let start = i;
+            let byte_start = char_to_byte[i];
             while i < len && is_ident_continue(Some(chars[i])) {
                 i += 1;
             }
             let text: String = chars[start..i].iter().collect();
+            let byte_end = if i < len { char_to_byte[i] } else { input.len() };
             let kind = match text.as_str() {
                 "true" => TokenKind::True,
                 "false" => TokenKind::False,
@@ -269,14 +290,14 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                 "mod" => TokenKind::Mod,
                 _ => TokenKind::Identifier,
             };
-            tokens.push(Token { kind, text });
+            tokens.push(Token { kind, text, byte_start, byte_end });
             continue;
         }
 
         return Err(format!("Unexpected character {c:?} at position {i}"));
     }
 
-    tokens.push(Token { kind: TokenKind::Eof, text: String::new() });
+    tokens.push(Token { kind: TokenKind::Eof, text: String::new(), byte_start: input.len(), byte_end: input.len() });
     Ok(tokens)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,10 @@ fn ast_to_pydict(py: Python<'_>, node: &AstNode, tokens: &[lexer::Token]) -> PyR
     // type
     dict.set_item("type", node.node_type)?;
 
+    // byte offsets into the source string
+    dict.set_item("start", node.byte_start)?;
+    dict.set_item("end", node.byte_end)?;
+
     // terminalNodeText
     let tnt = PyList::new(
         py,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,16 +10,21 @@ pub struct AstNode {
     /// Index range [token_start..token_end] into the token vec (for text computation).
     pub token_start: usize,
     pub token_end: usize,
+    /// Byte offsets into the source string.
+    pub byte_start: usize,
+    pub byte_end: usize,
 }
 
 impl AstNode {
-    fn new(node_type: &'static str, token_start: usize) -> Self {
+    fn new(node_type: &'static str, token_start: usize, tokens: &[Token]) -> Self {
         AstNode {
             node_type,
             terminal_node_text: Vec::new(),
             children: Vec::new(),
             token_start,
             token_end: token_start,
+            byte_start: tokens[token_start].byte_start,
+            byte_end: tokens[token_start].byte_start,
         }
     }
 }
@@ -59,6 +64,11 @@ impl<'a> Parser<'a> {
                 self.current().text
             ))
         }
+    }
+
+    fn set_end(&self, node: &mut AstNode) {
+        node.token_end = self.pos;
+        node.byte_end = self.tokens[self.pos.saturating_sub(1)].byte_end;
     }
 
     // ── Entry point ─────────────────────────────────────────────────────
@@ -115,11 +125,11 @@ impl<'a> Parser<'a> {
         while *self.peek() == TokenKind::Is || *self.peek() == TokenKind::As {
             let op_tok = self.advance().clone();
             let type_spec = self.parse_type_specifier()?;
-            let mut node = AstNode::new("TypeExpression", start);
+            let mut node = AstNode::new("TypeExpression", start, self.tokens);
             node.terminal_node_text.push(op_tok.text.clone());
             node.children.push(left);
             node.children.push(type_spec);
-            node.token_end = self.pos;
+            self.set_end(&mut node);
             left = node;
         }
         Ok(left)
@@ -158,10 +168,10 @@ impl<'a> Parser<'a> {
             let start = self.pos;
             let op_tok = self.advance().clone();
             let operand = self.parse_unary()?;
-            let mut node = AstNode::new("PolarityExpression", start);
+            let mut node = AstNode::new("PolarityExpression", start, self.tokens);
             node.terminal_node_text.push(op_tok.text.clone());
             node.children.push(operand);
-            node.token_end = self.pos;
+            self.set_end(&mut node);
             Ok(node)
         } else {
             self.parse_postfix()
@@ -175,22 +185,22 @@ impl<'a> Parser<'a> {
             if *self.peek() == TokenKind::Dot {
                 let dot = self.advance().clone();
                 let inv = self.parse_invocation()?;
-                let mut node = AstNode::new("InvocationExpression", start);
+                let mut node = AstNode::new("InvocationExpression", start, self.tokens);
                 node.terminal_node_text.push(dot.text.clone());
                 node.children.push(left);
                 node.children.push(inv);
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 left = node;
             } else if *self.peek() == TokenKind::LBracket {
                 let lb = self.advance().clone();
                 let index_expr = self.parse_expression()?;
                 let rb = self.expect(&TokenKind::RBracket)?.clone();
-                let mut node = AstNode::new("IndexerExpression", start);
+                let mut node = AstNode::new("IndexerExpression", start, self.tokens);
                 node.terminal_node_text.push(lb.text.clone());
                 node.terminal_node_text.push(rb.text.clone());
                 node.children.push(left);
                 node.children.push(index_expr);
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 left = node;
             } else {
                 break;
@@ -202,9 +212,9 @@ impl<'a> Parser<'a> {
     fn parse_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let inner = self.parse_term_inner()?;
-        let mut term_expr = AstNode::new("TermExpression", start);
+        let mut term_expr = AstNode::new("TermExpression", start, self.tokens);
         term_expr.children.push(inner);
-        term_expr.token_end = self.pos;
+        self.set_end(&mut term_expr);
         Ok(term_expr)
     }
 
@@ -245,11 +255,11 @@ impl<'a> Parser<'a> {
         let lp = self.advance().clone();
         let expr = self.parse_expression()?;
         let rp = self.expect(&TokenKind::RParen)?.clone();
-        let mut node = AstNode::new("ParenthesizedTerm", start);
+        let mut node = AstNode::new("ParenthesizedTerm", start, self.tokens);
         node.terminal_node_text.push(lp.text.clone());
         node.terminal_node_text.push(rp.text.clone());
         node.children.push(expr);
-        node.token_end = self.pos;
+        self.set_end(&mut node);
         Ok(node)
     }
 
@@ -269,37 +279,37 @@ impl<'a> Parser<'a> {
         let start = self.pos;
         let lb = self.advance().clone();
         let rb = self.expect(&TokenKind::RBrace)?.clone();
-        let mut literal = AstNode::new("NullLiteral", start);
+        let mut literal = AstNode::new("NullLiteral", start, self.tokens);
         literal.terminal_node_text.push(lb.text.clone());
         literal.terminal_node_text.push(rb.text.clone());
-        literal.token_end = self.pos;
-        let mut term = AstNode::new("LiteralTerm", start);
+        self.set_end(&mut literal);
+        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
         term.children.push(literal);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
     fn parse_boolean_literal_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let tok = self.advance().clone();
-        let mut literal = AstNode::new("BooleanLiteral", start);
+        let mut literal = AstNode::new("BooleanLiteral", start, self.tokens);
         literal.terminal_node_text.push(tok.text.clone());
-        literal.token_end = self.pos;
-        let mut term = AstNode::new("LiteralTerm", start);
+        self.set_end(&mut literal);
+        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
         term.children.push(literal);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
     fn parse_string_literal_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let tok = self.advance().clone();
-        let mut literal = AstNode::new("StringLiteral", start);
+        let mut literal = AstNode::new("StringLiteral", start, self.tokens);
         literal.terminal_node_text.push(tok.text.clone());
-        literal.token_end = self.pos;
-        let mut term = AstNode::new("LiteralTerm", start);
+        self.set_end(&mut literal);
+        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
         term.children.push(literal);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
@@ -310,24 +320,24 @@ impl<'a> Parser<'a> {
         // Check if next token is a unit (string literal or datetime precision word)
         if self.is_unit_start() {
             let unit_node = self.parse_unit()?;
-            let mut quantity = AstNode::new("Quantity", start);
+            let mut quantity = AstNode::new("Quantity", start, self.tokens);
             quantity.terminal_node_text.push(num_tok.text.clone());
             quantity.children.push(unit_node);
-            quantity.token_end = self.pos;
-            let mut ql = AstNode::new("QuantityLiteral", start);
+            self.set_end(&mut quantity);
+            let mut ql = AstNode::new("QuantityLiteral", start, self.tokens);
             ql.children.push(quantity);
-            ql.token_end = self.pos;
-            let mut term = AstNode::new("LiteralTerm", start);
+            self.set_end(&mut ql);
+            let mut term = AstNode::new("LiteralTerm", start, self.tokens);
             term.children.push(ql);
-            term.token_end = self.pos;
+            self.set_end(&mut term);
             Ok(term)
         } else {
-            let mut literal = AstNode::new("NumberLiteral", start);
+            let mut literal = AstNode::new("NumberLiteral", start, self.tokens);
             literal.terminal_node_text.push(num_tok.text.clone());
-            literal.token_end = self.pos;
-            let mut term = AstNode::new("LiteralTerm", start);
+            self.set_end(&mut literal);
+            let mut term = AstNode::new("LiteralTerm", start, self.tokens);
             term.children.push(literal);
-            term.token_end = self.pos;
+            self.set_end(&mut term);
             Ok(term)
         }
     }
@@ -345,7 +355,7 @@ impl<'a> Parser<'a> {
 
     fn parse_unit(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
-        let mut unit = AstNode::new("Unit", start);
+        let mut unit = AstNode::new("Unit", start, self.tokens);
         match self.peek() {
             TokenKind::String => {
                 let tok = self.advance().clone();
@@ -355,15 +365,15 @@ impl<'a> Parser<'a> {
                 let text = self.current().text.clone();
                 if is_datetime_precision(&text) {
                     let tok = self.advance().clone();
-                    let mut dtp = AstNode::new("DateTimePrecision", start);
+                    let mut dtp = AstNode::new("DateTimePrecision", start, self.tokens);
                     dtp.terminal_node_text.push(tok.text.clone());
-                    dtp.token_end = self.pos;
+                    self.set_end(&mut dtp);
                     unit.children.push(dtp);
                 } else if is_plural_datetime_precision(&text) {
                     let tok = self.advance().clone();
-                    let mut pdtp = AstNode::new("PluralDateTimePrecision", start);
+                    let mut pdtp = AstNode::new("PluralDateTimePrecision", start, self.tokens);
                     pdtp.terminal_node_text.push(tok.text.clone());
-                    pdtp.token_end = self.pos;
+                    self.set_end(&mut pdtp);
                     unit.children.push(pdtp);
                 } else {
                     return Err(format!("Expected unit but found identifier {:?}", text));
@@ -371,31 +381,31 @@ impl<'a> Parser<'a> {
             }
             _ => return Err("Expected unit".into()),
         }
-        unit.token_end = self.pos;
+        self.set_end(&mut unit);
         Ok(unit)
     }
 
     fn parse_datetime_literal_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let tok = self.advance().clone();
-        let mut literal = AstNode::new("DateTimeLiteral", start);
+        let mut literal = AstNode::new("DateTimeLiteral", start, self.tokens);
         literal.terminal_node_text.push(tok.text.clone());
-        literal.token_end = self.pos;
-        let mut term = AstNode::new("LiteralTerm", start);
+        self.set_end(&mut literal);
+        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
         term.children.push(literal);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
     fn parse_time_literal_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let tok = self.advance().clone();
-        let mut literal = AstNode::new("TimeLiteral", start);
+        let mut literal = AstNode::new("TimeLiteral", start, self.tokens);
         literal.terminal_node_text.push(tok.text.clone());
-        literal.token_end = self.pos;
-        let mut term = AstNode::new("LiteralTerm", start);
+        self.set_end(&mut literal);
+        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
         term.children.push(literal);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
@@ -406,29 +416,29 @@ impl<'a> Parser<'a> {
         let child = match self.peek() {
             TokenKind::String => {
                 let tok = self.advance().clone();
-                let mut id = AstNode::new("Identifier", start + 1);
+                let mut id = AstNode::new("Identifier", start + 1, self.tokens);
                 id.terminal_node_text.push(tok.text.clone());
-                id.token_end = self.pos;
+                self.set_end(&mut id);
                 id
             }
             _ => self.parse_identifier()?,
         };
-        let mut ext = AstNode::new("ExternalConstant", start);
+        let mut ext = AstNode::new("ExternalConstant", start, self.tokens);
         ext.terminal_node_text.push(pct.text.clone());
         ext.children.push(child);
-        ext.token_end = self.pos;
-        let mut term = AstNode::new("ExternalConstantTerm", start);
+        self.set_end(&mut ext);
+        let mut term = AstNode::new("ExternalConstantTerm", start, self.tokens);
         term.children.push(ext);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
     fn parse_invocation_term(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let inv = self.parse_invocation()?;
-        let mut term = AstNode::new("InvocationTerm", start);
+        let mut term = AstNode::new("InvocationTerm", start, self.tokens);
         term.children.push(inv);
-        term.token_end = self.pos;
+        self.set_end(&mut term);
         Ok(term)
     }
 
@@ -439,25 +449,25 @@ impl<'a> Parser<'a> {
             TokenKind::DollarThis => {
                 let start = self.pos;
                 let tok = self.advance().clone();
-                let mut node = AstNode::new("ThisInvocation", start);
+                let mut node = AstNode::new("ThisInvocation", start, self.tokens);
                 node.terminal_node_text.push(tok.text.clone());
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 Ok(node)
             }
             TokenKind::DollarIndex => {
                 let start = self.pos;
                 let tok = self.advance().clone();
-                let mut node = AstNode::new("IndexInvocation", start);
+                let mut node = AstNode::new("IndexInvocation", start, self.tokens);
                 node.terminal_node_text.push(tok.text.clone());
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 Ok(node)
             }
             TokenKind::DollarTotal => {
                 let start = self.pos;
                 let tok = self.advance().clone();
-                let mut node = AstNode::new("TotalInvocation", start);
+                let mut node = AstNode::new("TotalInvocation", start, self.tokens);
                 node.terminal_node_text.push(tok.text.clone());
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 Ok(node)
             }
             TokenKind::Identifier
@@ -472,9 +482,9 @@ impl<'a> Parser<'a> {
                 if *self.peek() == TokenKind::LParen {
                     self.parse_function_invocation(start, ident)
                 } else {
-                    let mut node = AstNode::new("MemberInvocation", start);
+                    let mut node = AstNode::new("MemberInvocation", start, self.tokens);
                     node.children.push(ident);
-                    node.token_end = self.pos;
+                    self.set_end(&mut node);
                     Ok(node)
                 }
             }
@@ -492,7 +502,7 @@ impl<'a> Parser<'a> {
         ident: AstNode,
     ) -> Result<AstNode, String> {
         let lp = self.advance().clone();
-        let mut functn = AstNode::new("Functn", start);
+        let mut functn = AstNode::new("Functn", start, self.tokens);
         functn.terminal_node_text.push(lp.text.clone());
         functn.children.push(ident);
         if *self.peek() != TokenKind::RParen {
@@ -501,16 +511,16 @@ impl<'a> Parser<'a> {
         }
         let rp = self.expect(&TokenKind::RParen)?.clone();
         functn.terminal_node_text.push(rp.text.clone());
-        functn.token_end = self.pos;
-        let mut fi = AstNode::new("FunctionInvocation", start);
+        self.set_end(&mut functn);
+        let mut fi = AstNode::new("FunctionInvocation", start, self.tokens);
         fi.children.push(functn);
-        fi.token_end = self.pos;
+        self.set_end(&mut fi);
         Ok(fi)
     }
 
     fn parse_param_list(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
-        let mut pl = AstNode::new("ParamList", start);
+        let mut pl = AstNode::new("ParamList", start, self.tokens);
         let first = self.parse_expression()?;
         pl.children.push(first);
         while *self.peek() == TokenKind::Comma {
@@ -519,7 +529,7 @@ impl<'a> Parser<'a> {
             let next = self.parse_expression()?;
             pl.children.push(next);
         }
-        pl.token_end = self.pos;
+        self.set_end(&mut pl);
         Ok(pl)
     }
 
@@ -535,9 +545,9 @@ impl<'a> Parser<'a> {
             | TokenKind::In => {
                 let start = self.pos;
                 let tok = self.advance().clone();
-                let mut node = AstNode::new("Identifier", start);
+                let mut node = AstNode::new("Identifier", start, self.tokens);
                 node.terminal_node_text.push(tok.text.clone());
-                node.token_end = self.pos;
+                self.set_end(&mut node);
                 Ok(node)
             }
             _ => Err(format!(
@@ -553,15 +563,15 @@ impl<'a> Parser<'a> {
     fn parse_type_specifier(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
         let qi = self.parse_qualified_identifier()?;
-        let mut ts = AstNode::new("TypeSpecifier", start);
+        let mut ts = AstNode::new("TypeSpecifier", start, self.tokens);
         ts.children.push(qi);
-        ts.token_end = self.pos;
+        self.set_end(&mut ts);
         Ok(ts)
     }
 
     fn parse_qualified_identifier(&mut self) -> Result<AstNode, String> {
         let start = self.pos;
-        let mut qi = AstNode::new("QualifiedIdentifier", start);
+        let mut qi = AstNode::new("QualifiedIdentifier", start, self.tokens);
         let first = self.parse_identifier()?;
         qi.children.push(first);
         while *self.peek() == TokenKind::Dot {
@@ -570,7 +580,7 @@ impl<'a> Parser<'a> {
             let next = self.parse_identifier()?;
             qi.children.push(next);
         }
-        qi.token_end = self.pos;
+        self.set_end(&mut qi);
         Ok(qi)
     }
 
@@ -587,11 +597,11 @@ impl<'a> Parser<'a> {
         while ops.contains(self.peek()) {
             let op_tok = self.advance().clone();
             let right = next(self)?;
-            let mut node = AstNode::new(node_type, start);
+            let mut node = AstNode::new(node_type, start, self.tokens);
             node.terminal_node_text.push(op_tok.text.clone());
             node.children.push(left);
             node.children.push(right);
-            node.token_end = self.pos;
+            self.set_end(&mut node);
             left = node;
         }
         Ok(left)

--- a/tests/fixtures/ast/%v+2.json
+++ b/tests/fixtures/ast/%v+2.json
@@ -1,38 +1,77 @@
 {
-  "children": [{
-    "type": "AdditiveExpression",
-    "terminalNodeText": ["+"],
-    "children": [{
-      "type": "TermExpression",
-      "text": "%v",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "ExternalConstantTerm",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "ExternalConstant",
-          "terminalNodeText": ["%"],
-          "children": [{
-            "type": "Identifier",
-            "text": "v",
-            "terminalNodeText": ["v"]
-          }]
-        }]
-      }]
-    }, {
-      "type": "TermExpression",
-      "text": "2",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "LiteralTerm",
-        "text": "2",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "NumberLiteral",
+  "children": [
+    {
+      "type": "AdditiveExpression",
+      "start": 0,
+      "end": 4,
+      "terminalNodeText": [
+        "+"
+      ],
+      "children": [
+        {
+          "type": "TermExpression",
+          "start": 0,
+          "end": 2,
+          "terminalNodeText": [],
+          "text": "%v",
+          "children": [
+            {
+              "type": "ExternalConstantTerm",
+              "start": 0,
+              "end": 2,
+              "terminalNodeText": [],
+              "children": [
+                {
+                  "type": "ExternalConstant",
+                  "start": 0,
+                  "end": 2,
+                  "terminalNodeText": [
+                    "%"
+                  ],
+                  "children": [
+                    {
+                      "type": "Identifier",
+                      "start": 1,
+                      "end": 2,
+                      "terminalNodeText": [
+                        "v"
+                      ],
+                      "text": "v"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TermExpression",
+          "start": 3,
+          "end": 4,
+          "terminalNodeText": [],
           "text": "2",
-          "terminalNodeText": ["2"]
-        }]
-      }]
-    }]
-  }]
+          "children": [
+            {
+              "type": "LiteralTerm",
+              "start": 3,
+              "end": 4,
+              "terminalNodeText": [],
+              "text": "2",
+              "children": [
+                {
+                  "type": "NumberLiteral",
+                  "start": 3,
+                  "end": 4,
+                  "terminalNodeText": [
+                    "2"
+                  ],
+                  "text": "2"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/ast/Observation.value.json
+++ b/tests/fixtures/ast/Observation.value.json
@@ -1,33 +1,66 @@
 {
-  "children": [{
-    "type": "InvocationExpression",
-    "text": "Observation.value",
-    "terminalNodeText": ["."],
-    "children": [{
-      "type": "TermExpression",
-      "text": "Observation",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "InvocationTerm",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "MemberInvocation",
+  "children": [
+    {
+      "type": "InvocationExpression",
+      "start": 0,
+      "end": 17,
+      "terminalNodeText": [
+        "."
+      ],
+      "text": "Observation.value",
+      "children": [
+        {
+          "type": "TermExpression",
+          "start": 0,
+          "end": 11,
           "terminalNodeText": [],
-          "children": [{
-            "type": "Identifier",
-            "text": "Observation",
-            "terminalNodeText": ["Observation"]
-          }]
-        }]
-      }]
-    }, {
-      "type": "MemberInvocation",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "Identifier",
-        "text": "value",
-        "terminalNodeText": ["value"]
-      }]
-    }]
-  }]
+          "text": "Observation",
+          "children": [
+            {
+              "type": "InvocationTerm",
+              "start": 0,
+              "end": 11,
+              "terminalNodeText": [],
+              "children": [
+                {
+                  "type": "MemberInvocation",
+                  "start": 0,
+                  "end": 11,
+                  "terminalNodeText": [],
+                  "children": [
+                    {
+                      "type": "Identifier",
+                      "start": 0,
+                      "end": 11,
+                      "terminalNodeText": [
+                        "Observation"
+                      ],
+                      "text": "Observation"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "MemberInvocation",
+          "start": 12,
+          "end": 17,
+          "terminalNodeText": [],
+          "children": [
+            {
+              "type": "Identifier",
+              "start": 12,
+              "end": 17,
+              "terminalNodeText": [
+                "value"
+              ],
+              "text": "value"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/ast/Patient.name.given.json
+++ b/tests/fixtures/ast/Patient.name.given.json
@@ -1,46 +1,94 @@
 {
-  "children": [{
-    "type": "InvocationExpression",
-    "text": "Patient.name.given",
-    "terminalNodeText": ["."],
-    "children": [{
+  "children": [
+    {
       "type": "InvocationExpression",
-      "text": "Patient.name",
-      "terminalNodeText": ["."],
-      "children": [{
-        "type": "TermExpression",
-        "text": "Patient",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "InvocationTerm",
-          "terminalNodeText": [],
-          "children": [{
-            "type": "MemberInvocation",
-            "terminalNodeText": [],
-            "children": [{
-              "type": "Identifier",
+      "start": 0,
+      "end": 18,
+      "terminalNodeText": [
+        "."
+      ],
+      "text": "Patient.name.given",
+      "children": [
+        {
+          "type": "InvocationExpression",
+          "start": 0,
+          "end": 12,
+          "terminalNodeText": [
+            "."
+          ],
+          "text": "Patient.name",
+          "children": [
+            {
+              "type": "TermExpression",
+              "start": 0,
+              "end": 7,
+              "terminalNodeText": [],
               "text": "Patient",
-              "terminalNodeText": ["Patient"]
-            }]
-          }]
-        }]
-      }, {
-        "type": "MemberInvocation",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "Identifier",
-          "text": "name",
-          "terminalNodeText": ["name"]
-        }]
-      }]
-    }, {
-      "type": "MemberInvocation",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "Identifier",
-        "text": "given",
-        "terminalNodeText": ["given"]
-      }]
-    }]
-  }]
+              "children": [
+                {
+                  "type": "InvocationTerm",
+                  "start": 0,
+                  "end": 7,
+                  "terminalNodeText": [],
+                  "children": [
+                    {
+                      "type": "MemberInvocation",
+                      "start": 0,
+                      "end": 7,
+                      "terminalNodeText": [],
+                      "children": [
+                        {
+                          "type": "Identifier",
+                          "start": 0,
+                          "end": 7,
+                          "terminalNodeText": [
+                            "Patient"
+                          ],
+                          "text": "Patient"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "MemberInvocation",
+              "start": 8,
+              "end": 12,
+              "terminalNodeText": [],
+              "children": [
+                {
+                  "type": "Identifier",
+                  "start": 8,
+                  "end": 12,
+                  "terminalNodeText": [
+                    "name"
+                  ],
+                  "text": "name"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "MemberInvocation",
+          "start": 13,
+          "end": 18,
+          "terminalNodeText": [],
+          "children": [
+            {
+              "type": "Identifier",
+              "start": 13,
+              "end": 18,
+              "terminalNodeText": [
+                "given"
+              ],
+              "text": "given"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/ast/a.b+2.json
+++ b/tests/fixtures/ast/a.b+2.json
@@ -1,51 +1,103 @@
 {
-  "children": [{
-    "type": "AdditiveExpression",
-    "terminalNodeText": ["+"],
-    "children": [{
-      "type": "InvocationExpression",
-      "text": "a.b",
-      "terminalNodeText": ["."],
-      "children": [{
-        "type": "TermExpression",
-        "text": "a",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "InvocationTerm",
-          "terminalNodeText": [],
-          "children": [{
-            "type": "MemberInvocation",
-            "terminalNodeText": [],
-            "children": [{
-              "type": "Identifier",
+  "children": [
+    {
+      "type": "AdditiveExpression",
+      "start": 0,
+      "end": 5,
+      "terminalNodeText": [
+        "+"
+      ],
+      "children": [
+        {
+          "type": "InvocationExpression",
+          "start": 0,
+          "end": 3,
+          "terminalNodeText": [
+            "."
+          ],
+          "text": "a.b",
+          "children": [
+            {
+              "type": "TermExpression",
+              "start": 0,
+              "end": 1,
+              "terminalNodeText": [],
               "text": "a",
-              "terminalNodeText": ["a"]
-            }]
-          }]
-        }]
-      }, {
-        "type": "MemberInvocation",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "Identifier",
-          "text": "b",
-          "terminalNodeText": ["b"]
-        }]
-      }]
-    }, {
-      "type": "TermExpression",
-      "text": "2",
-      "terminalNodeText": [],
-      "children": [{
-        "type": "LiteralTerm",
-        "text": "2",
-        "terminalNodeText": [],
-        "children": [{
-          "type": "NumberLiteral",
+              "children": [
+                {
+                  "type": "InvocationTerm",
+                  "start": 0,
+                  "end": 1,
+                  "terminalNodeText": [],
+                  "children": [
+                    {
+                      "type": "MemberInvocation",
+                      "start": 0,
+                      "end": 1,
+                      "terminalNodeText": [],
+                      "children": [
+                        {
+                          "type": "Identifier",
+                          "start": 0,
+                          "end": 1,
+                          "terminalNodeText": [
+                            "a"
+                          ],
+                          "text": "a"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "MemberInvocation",
+              "start": 2,
+              "end": 3,
+              "terminalNodeText": [],
+              "children": [
+                {
+                  "type": "Identifier",
+                  "start": 2,
+                  "end": 3,
+                  "terminalNodeText": [
+                    "b"
+                  ],
+                  "text": "b"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TermExpression",
+          "start": 4,
+          "end": 5,
+          "terminalNodeText": [],
           "text": "2",
-          "terminalNodeText": ["2"]
-        }]
-      }]
-    }]
-  }]
+          "children": [
+            {
+              "type": "LiteralTerm",
+              "start": 4,
+              "end": 5,
+              "terminalNodeText": [],
+              "text": "2",
+              "children": [
+                {
+                  "type": "NumberLiteral",
+                  "start": 4,
+                  "end": 5,
+                  "terminalNodeText": [
+                    "2"
+                  ],
+                  "text": "2"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/ast/golden_asts.json
+++ b/tests/fixtures/ast/golden_asts.json
@@ -3,19 +3,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 1,
         "terminalNodeText": [],
         "text": "x",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "MemberInvocation",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [
                       "x"
                     ],
@@ -33,19 +41,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [],
         "text": "Patient",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "MemberInvocation",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [
                       "Patient"
                     ],
@@ -63,19 +79,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 8,
         "terminalNodeText": [],
         "text": "_private",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 8,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "MemberInvocation",
+                "start": 0,
+                "end": 8,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 0,
+                    "end": 8,
                     "terminalNodeText": [
                       "_private"
                     ],
@@ -93,16 +117,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 4,
         "terminalNodeText": [],
         "text": "true",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "true",
             "children": [
               {
                 "type": "BooleanLiteral",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [
                   "true"
                 ],
@@ -118,16 +148,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [],
         "text": "false",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "text": "false",
             "children": [
               {
                 "type": "BooleanLiteral",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [
                   "false"
                 ],
@@ -143,16 +179,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 2,
         "terminalNodeText": [],
         "text": "{}",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 2,
             "terminalNodeText": [],
             "text": "{}",
             "children": [
               {
                 "type": "NullLiteral",
+                "start": 0,
+                "end": 2,
                 "terminalNodeText": [
                   "{",
                   "}"
@@ -169,16 +211,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [],
         "text": "'hello'",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "'hello'",
             "children": [
               {
                 "type": "StringLiteral",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [
                   "'hello'"
                 ],
@@ -194,16 +242,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 13,
         "terminalNodeText": [],
         "text": "'hello world'",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 13,
             "terminalNodeText": [],
             "text": "'hello world'",
             "children": [
               {
                 "type": "StringLiteral",
+                "start": 0,
+                "end": 13,
                 "terminalNodeText": [
                   "'hello world'"
                 ],
@@ -219,16 +273,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 2,
         "terminalNodeText": [],
         "text": "42",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 2,
             "terminalNodeText": [],
             "text": "42",
             "children": [
               {
                 "type": "NumberLiteral",
+                "start": 0,
+                "end": 2,
                 "terminalNodeText": [
                   "42"
                 ],
@@ -244,16 +304,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 4,
         "terminalNodeText": [],
         "text": "3.14",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "3.14",
             "children": [
               {
                 "type": "NumberLiteral",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [
                   "3.14"
                 ],
@@ -269,16 +335,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 1,
         "terminalNodeText": [],
         "text": "0",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "0",
             "children": [
               {
                 "type": "NumberLiteral",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [
                   "0"
                 ],
@@ -294,16 +366,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [],
         "text": "@2024",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "text": "@2024",
             "children": [
               {
                 "type": "DateTimeLiteral",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [
                   "@2024"
                 ],
@@ -319,16 +397,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 8,
         "terminalNodeText": [],
         "text": "@2024-01",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 8,
             "terminalNodeText": [],
             "text": "@2024-01",
             "children": [
               {
                 "type": "DateTimeLiteral",
+                "start": 0,
+                "end": 8,
                 "terminalNodeText": [
                   "@2024-01"
                 ],
@@ -344,16 +428,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 11,
         "terminalNodeText": [],
         "text": "@2024-01-15",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 11,
             "terminalNodeText": [],
             "text": "@2024-01-15",
             "children": [
               {
                 "type": "DateTimeLiteral",
+                "start": 0,
+                "end": 11,
                 "terminalNodeText": [
                   "@2024-01-15"
                 ],
@@ -369,16 +459,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 20,
         "terminalNodeText": [],
         "text": "@2024-01-15T10:30:00",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 20,
             "terminalNodeText": [],
             "text": "@2024-01-15T10:30:00",
             "children": [
               {
                 "type": "DateTimeLiteral",
+                "start": 0,
+                "end": 20,
                 "terminalNodeText": [
                   "@2024-01-15T10:30:00"
                 ],
@@ -394,16 +490,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 21,
         "terminalNodeText": [],
         "text": "@2024-01-15T10:30:00Z",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 21,
             "terminalNodeText": [],
             "text": "@2024-01-15T10:30:00Z",
             "children": [
               {
                 "type": "DateTimeLiteral",
+                "start": 0,
+                "end": 21,
                 "terminalNodeText": [
                   "@2024-01-15T10:30:00Z"
                 ],
@@ -419,16 +521,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [],
         "text": "@T10:30",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "@T10:30",
             "children": [
               {
                 "type": "TimeLiteral",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [
                   "@T10:30"
                 ],
@@ -444,16 +552,22 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 10,
         "terminalNodeText": [],
         "text": "@T10:30:00",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 10,
             "terminalNodeText": [],
             "text": "@T10:30:00",
             "children": [
               {
                 "type": "TimeLiteral",
+                "start": 0,
+                "end": 10,
                 "terminalNodeText": [
                   "@T10:30:00"
                 ],
@@ -469,27 +583,37 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [],
         "text": "10'mg'",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "10'mg'",
             "children": [
               {
                 "type": "QuantityLiteral",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "text": "10'mg'",
                 "children": [
                   {
                     "type": "Quantity",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [
                       "10"
                     ],
                     "children": [
                       {
                         "type": "Unit",
+                        "start": 3,
+                        "end": 7,
                         "terminalNodeText": [
                           "'mg'"
                         ]
@@ -508,31 +632,43 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [],
         "text": "5days",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 6,
             "terminalNodeText": [],
             "text": "5days",
             "children": [
               {
                 "type": "QuantityLiteral",
+                "start": 0,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "5days",
                 "children": [
                   {
                     "type": "Quantity",
+                    "start": 0,
+                    "end": 6,
                     "terminalNodeText": [
                       "5"
                     ],
                     "children": [
                       {
                         "type": "Unit",
+                        "start": 2,
+                        "end": 6,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "PluralDateTimePrecision",
+                            "start": 2,
+                            "end": 6,
                             "terminalNodeText": [
                               "days"
                             ]
@@ -553,31 +689,43 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [],
         "text": "1year",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 6,
             "terminalNodeText": [],
             "text": "1year",
             "children": [
               {
                 "type": "QuantityLiteral",
+                "start": 0,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "1year",
                 "children": [
                   {
                     "type": "Quantity",
+                    "start": 0,
+                    "end": 6,
                     "terminalNodeText": [
                       "1"
                     ],
                     "children": [
                       {
                         "type": "Unit",
+                        "start": 2,
+                        "end": 6,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "DateTimePrecision",
+                            "start": 2,
+                            "end": 6,
                             "terminalNodeText": [
                               "year"
                             ]
@@ -598,27 +746,37 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 8,
         "terminalNodeText": [],
         "text": "2.5'cm'",
         "children": [
           {
             "type": "LiteralTerm",
+            "start": 0,
+            "end": 8,
             "terminalNodeText": [],
             "text": "2.5'cm'",
             "children": [
               {
                 "type": "QuantityLiteral",
+                "start": 0,
+                "end": 8,
                 "terminalNodeText": [],
                 "text": "2.5'cm'",
                 "children": [
                   {
                     "type": "Quantity",
+                    "start": 0,
+                    "end": 8,
                     "terminalNodeText": [
                       "2.5"
                     ],
                     "children": [
                       {
                         "type": "Unit",
+                        "start": 4,
+                        "end": 8,
                         "terminalNodeText": [
                           "'cm'"
                         ]
@@ -637,21 +795,29 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 8,
         "terminalNodeText": [],
         "text": "%context",
         "children": [
           {
             "type": "ExternalConstantTerm",
+            "start": 0,
+            "end": 8,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "ExternalConstant",
+                "start": 0,
+                "end": 8,
                 "terminalNodeText": [
                   "%"
                 ],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 1,
+                    "end": 8,
                     "terminalNodeText": [
                       "context"
                     ],
@@ -669,21 +835,29 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 3,
         "terminalNodeText": [],
         "text": "%vs",
         "children": [
           {
             "type": "ExternalConstantTerm",
+            "start": 0,
+            "end": 3,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "ExternalConstant",
+                "start": 0,
+                "end": 3,
                 "terminalNodeText": [
                   "%"
                 ],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 1,
+                    "end": 3,
                     "terminalNodeText": [
                       "vs"
                     ],
@@ -701,11 +875,15 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [],
         "text": "(1+2)",
         "children": [
           {
             "type": "ParenthesizedTerm",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [
               "(",
               ")"
@@ -713,22 +891,30 @@
             "children": [
               {
                 "type": "AdditiveExpression",
+                "start": 1,
+                "end": 6,
                 "terminalNodeText": [
                   "+"
                 ],
                 "children": [
                   {
                     "type": "TermExpression",
+                    "start": 1,
+                    "end": 2,
                     "terminalNodeText": [],
                     "text": "1",
                     "children": [
                       {
                         "type": "LiteralTerm",
+                        "start": 1,
+                        "end": 2,
                         "terminalNodeText": [],
                         "text": "1",
                         "children": [
                           {
                             "type": "NumberLiteral",
+                            "start": 1,
+                            "end": 2,
                             "terminalNodeText": [
                               "1"
                             ],
@@ -740,16 +926,22 @@
                   },
                   {
                     "type": "TermExpression",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "text": "2",
                     "children": [
                       {
                         "type": "LiteralTerm",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [],
                         "text": "2",
                         "children": [
                           {
                             "type": "NumberLiteral",
+                            "start": 5,
+                            "end": 6,
                             "terminalNodeText": [
                               "2"
                             ],
@@ -771,15 +963,21 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [],
         "text": "$this",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "ThisInvocation",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [
                   "$this"
                 ]
@@ -794,15 +992,21 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [],
         "text": "$index",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 6,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "IndexInvocation",
+                "start": 0,
+                "end": 6,
                 "terminalNodeText": [
                   "$index"
                 ]
@@ -817,15 +1021,21 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [],
         "text": "$total",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 6,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "TotalInvocation",
+                "start": 0,
+                "end": 6,
                 "terminalNodeText": [
                   "$total"
                 ]
@@ -840,6 +1050,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [
           "."
         ],
@@ -847,19 +1059,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "Patient",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "Patient"
                         ],
@@ -873,10 +1093,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 8,
+            "end": 12,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 8,
+                "end": 12,
                 "terminalNodeText": [
                   "name"
                 ],
@@ -892,6 +1116,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 18,
         "terminalNodeText": [
           "."
         ],
@@ -899,6 +1125,8 @@
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 12,
             "terminalNodeText": [
               "."
             ],
@@ -906,19 +1134,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "text": "Patient",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 7,
                             "terminalNodeText": [
                               "Patient"
                             ],
@@ -932,10 +1168,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 8,
+                "end": 12,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 8,
+                    "end": 12,
                     "terminalNodeText": [
                       "name"
                     ],
@@ -947,10 +1187,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 13,
+            "end": 18,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 13,
+                "end": 18,
                 "terminalNodeText": [
                   "given"
                 ],
@@ -966,6 +1210,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "."
         ],
@@ -973,6 +1219,8 @@
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [
               "."
             ],
@@ -980,6 +1228,8 @@
             "children": [
               {
                 "type": "InvocationExpression",
+                "start": 0,
+                "end": 3,
                 "terminalNodeText": [
                   "."
                 ],
@@ -987,19 +1237,27 @@
                 "children": [
                   {
                     "type": "TermExpression",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "text": "a",
                     "children": [
                       {
                         "type": "InvocationTerm",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "MemberInvocation",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "Identifier",
+                                "start": 0,
+                                "end": 1,
                                 "terminalNodeText": [
                                   "a"
                                 ],
@@ -1013,10 +1271,14 @@
                   },
                   {
                     "type": "MemberInvocation",
+                    "start": 2,
+                    "end": 3,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 2,
+                        "end": 3,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -1028,10 +1290,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [
                       "c"
                     ],
@@ -1043,10 +1309,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 6,
+            "end": 7,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [
                   "d"
                 ],
@@ -1062,6 +1332,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 13,
         "terminalNodeText": [
           "."
         ],
@@ -1069,19 +1341,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "name",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [
                           "name"
                         ],
@@ -1095,10 +1375,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 5,
+            "end": 13,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 5,
+                "end": 13,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -1106,6 +1390,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 5,
+                    "end": 11,
                     "terminalNodeText": [
                       "exists"
                     ],
@@ -1123,6 +1409,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [
           "."
         ],
@@ -1130,19 +1418,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "name",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [
                           "name"
                         ],
@@ -1156,10 +1452,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 5,
+            "end": 12,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 5,
+                "end": 12,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -1167,6 +1467,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 5,
+                    "end": 10,
                     "terminalNodeText": [
                       "count"
                     ],
@@ -1184,6 +1486,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 28,
         "terminalNodeText": [
           "."
         ],
@@ -1191,19 +1495,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "name",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [
                           "name"
                         ],
@@ -1217,10 +1529,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 5,
+            "end": 28,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 5,
+                "end": 28,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -1228,6 +1544,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 5,
+                    "end": 10,
                     "terminalNodeText": [
                       "where"
                     ],
@@ -1235,29 +1553,41 @@
                   },
                   {
                     "type": "ParamList",
+                    "start": 11,
+                    "end": 27,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "EqualityExpression",
+                        "start": 11,
+                        "end": 27,
                         "terminalNodeText": [
                           "="
                         ],
                         "children": [
                           {
                             "type": "TermExpression",
+                            "start": 11,
+                            "end": 14,
                             "terminalNodeText": [],
                             "text": "use",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 11,
+                                "end": 14,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 11,
+                                    "end": 14,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 11,
+                                        "end": 14,
                                         "terminalNodeText": [
                                           "use"
                                         ],
@@ -1271,16 +1601,22 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 17,
+                            "end": 27,
                             "terminalNodeText": [],
                             "text": "'official'",
                             "children": [
                               {
                                 "type": "LiteralTerm",
+                                "start": 17,
+                                "end": 27,
                                 "terminalNodeText": [],
                                 "text": "'official'",
                                 "children": [
                                   {
                                     "type": "StringLiteral",
+                                    "start": 17,
+                                    "end": 27,
                                     "terminalNodeText": [
                                       "'official'"
                                     ],
@@ -1306,19 +1642,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [],
         "text": "iif(a,b,c)",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 12,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "FunctionInvocation",
+                "start": 0,
+                "end": 12,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Functn",
+                    "start": 0,
+                    "end": 12,
                     "terminalNodeText": [
                       "(",
                       ")"
@@ -1326,6 +1670,8 @@
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 3,
                         "terminalNodeText": [
                           "iif"
                         ],
@@ -1333,6 +1679,8 @@
                       },
                       {
                         "type": "ParamList",
+                        "start": 4,
+                        "end": 11,
                         "terminalNodeText": [
                           ",",
                           ","
@@ -1340,19 +1688,27 @@
                         "children": [
                           {
                             "type": "TermExpression",
+                            "start": 4,
+                            "end": 5,
                             "terminalNodeText": [],
                             "text": "a",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 4,
+                                "end": 5,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 4,
+                                    "end": 5,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 4,
+                                        "end": 5,
                                         "terminalNodeText": [
                                           "a"
                                         ],
@@ -1366,19 +1722,27 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 7,
+                            "end": 8,
                             "terminalNodeText": [],
                             "text": "b",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 7,
+                                "end": 8,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 7,
+                                    "end": 8,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 7,
+                                        "end": 8,
                                         "terminalNodeText": [
                                           "b"
                                         ],
@@ -1392,19 +1756,27 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 10,
+                            "end": 11,
                             "terminalNodeText": [],
                             "text": "c",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 10,
+                                "end": 11,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 10,
+                                    "end": 11,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 10,
+                                        "end": 11,
                                         "terminalNodeText": [
                                           "c"
                                         ],
@@ -1432,6 +1804,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 15,
         "terminalNodeText": [
           "."
         ],
@@ -1439,19 +1813,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 10,
             "terminalNodeText": [],
             "text": "children()",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 10,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "FunctionInvocation",
+                    "start": 0,
+                    "end": 10,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Functn",
+                        "start": 0,
+                        "end": 10,
                         "terminalNodeText": [
                           "(",
                           ")"
@@ -1459,6 +1841,8 @@
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 8,
                             "terminalNodeText": [
                               "children"
                             ],
@@ -1474,10 +1858,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 11,
+            "end": 15,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 11,
+                "end": 15,
                 "terminalNodeText": [
                   "name"
                 ],
@@ -1493,6 +1881,8 @@
     "children": [
       {
         "type": "IndexerExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "[",
           "]"
@@ -1500,19 +1890,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "name",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [
                           "name"
                         ],
@@ -1526,16 +1924,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "0",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "0",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [
                       "0"
                     ],
@@ -1553,6 +1957,8 @@
     "children": [
       {
         "type": "IndexerExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "[",
           "]"
@@ -1560,6 +1966,8 @@
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 3,
             "terminalNodeText": [
               "."
             ],
@@ -1567,19 +1975,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "a",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [
                               "a"
                             ],
@@ -1593,10 +2009,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 2,
+                "end": 3,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 2,
+                    "end": 3,
                     "terminalNodeText": [
                       "b"
                     ],
@@ -1608,16 +2028,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "0",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "text": "0",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [
                       "0"
                     ],
@@ -1635,6 +2061,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "."
         ],
@@ -1642,6 +2070,8 @@
         "children": [
           {
             "type": "IndexerExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [
               "[",
               "]"
@@ -1649,19 +2079,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "a",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [
                               "a"
                             ],
@@ -1675,16 +2113,22 @@
               },
               {
                 "type": "TermExpression",
+                "start": 2,
+                "end": 3,
                 "terminalNodeText": [],
                 "text": "0",
                 "children": [
                   {
                     "type": "LiteralTerm",
+                    "start": 2,
+                    "end": 3,
                     "terminalNodeText": [],
                     "text": "0",
                     "children": [
                       {
                         "type": "NumberLiteral",
+                        "start": 2,
+                        "end": 3,
                         "terminalNodeText": [
                           "0"
                         ],
@@ -1698,10 +2142,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [
                   "b"
                 ],
@@ -1717,22 +2165,30 @@
     "children": [
       {
         "type": "PolarityExpression",
+        "start": 0,
+        "end": 2,
         "terminalNodeText": [
           "-"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 1,
+            "end": 2,
             "terminalNodeText": [],
             "text": "5",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 1,
+                "end": 2,
                 "terminalNodeText": [],
                 "text": "5",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 1,
+                    "end": 2,
                     "terminalNodeText": [
                       "5"
                     ],
@@ -1750,22 +2206,30 @@
     "children": [
       {
         "type": "PolarityExpression",
+        "start": 0,
+        "end": 2,
         "terminalNodeText": [
           "+"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 1,
+            "end": 2,
             "terminalNodeText": [],
             "text": "5",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 1,
+                "end": 2,
                 "terminalNodeText": [],
                 "text": "5",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 1,
+                    "end": 2,
                     "terminalNodeText": [
                       "5"
                     ],
@@ -1783,25 +2247,35 @@
     "children": [
       {
         "type": "PolarityExpression",
+        "start": 0,
+        "end": 2,
         "terminalNodeText": [
           "-"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 1,
+            "end": 2,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 1,
+                "end": 2,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 1,
+                    "end": 2,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 1,
+                        "end": 2,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -1821,25 +2295,35 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "*"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -1853,19 +2337,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -1885,25 +2377,35 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "/"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -1917,19 +2419,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -1949,25 +2459,35 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "div"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -1981,19 +2501,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 6,
+            "end": 7,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 6,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 6,
+                        "end": 7,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2013,25 +2541,35 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "mod"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2045,19 +2583,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 6,
+            "end": 7,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 6,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 6,
+                        "end": 7,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2077,22 +2623,30 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "*"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 2,
             "terminalNodeText": [],
             "text": "10",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 0,
+                "end": 2,
                 "terminalNodeText": [],
                 "text": "10",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 0,
+                    "end": 2,
                     "terminalNodeText": [
                       "10"
                     ],
@@ -2104,16 +2658,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "3",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "3",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [
                       "3"
                     ],
@@ -2131,25 +2691,35 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "+"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2163,19 +2733,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2195,25 +2773,35 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "-"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2227,19 +2815,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2259,25 +2855,35 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "&"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2291,19 +2897,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2323,22 +2937,30 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "+"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "1",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "1",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [
                       "1"
                     ],
@@ -2350,16 +2972,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "2",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "text": "2",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [
                       "2"
                     ],
@@ -2377,25 +3005,35 @@
     "children": [
       {
         "type": "UnionExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "|"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2409,19 +3047,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2441,31 +3087,43 @@
     "children": [
       {
         "type": "UnionExpression",
+        "start": 0,
+        "end": 9,
         "terminalNodeText": [
           "|"
         ],
         "children": [
           {
             "type": "UnionExpression",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [
               "|"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "a",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [
                               "a"
                             ],
@@ -2479,19 +3137,27 @@
               },
               {
                 "type": "TermExpression",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "text": "b",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 4,
+                            "end": 5,
                             "terminalNodeText": [
                               "b"
                             ],
@@ -2507,19 +3173,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 8,
+            "end": 9,
             "terminalNodeText": [],
             "text": "c",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 8,
+                "end": 9,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 8,
+                    "end": 9,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 8,
+                        "end": 9,
                         "terminalNodeText": [
                           "c"
                         ],
@@ -2539,25 +3213,35 @@
     "children": [
       {
         "type": "InequalityExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "<"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2571,19 +3255,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2603,25 +3295,35 @@
     "children": [
       {
         "type": "InequalityExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           ">"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2635,19 +3337,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2667,25 +3377,35 @@
     "children": [
       {
         "type": "InequalityExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "<="
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2699,19 +3419,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2731,25 +3459,35 @@
     "children": [
       {
         "type": "InequalityExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           ">="
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -2763,19 +3501,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -2795,25 +3541,35 @@
     "children": [
       {
         "type": "InequalityExpression",
+        "start": 0,
+        "end": 11,
         "terminalNodeText": [
           ">"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "count()",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "FunctionInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Functn",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "(",
                           ")"
@@ -2821,6 +3577,8 @@
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 5,
                             "terminalNodeText": [
                               "count"
                             ],
@@ -2836,16 +3594,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 10,
+            "end": 11,
             "terminalNodeText": [],
             "text": "0",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 10,
+                "end": 11,
                 "terminalNodeText": [],
                 "text": "0",
                 "children": [
                   {
                     "type": "NumberLiteral",
+                    "start": 10,
+                    "end": 11,
                     "terminalNodeText": [
                       "0"
                     ],
@@ -2863,25 +3627,35 @@
     "children": [
       {
         "type": "TypeExpression",
+        "start": 0,
+        "end": 15,
         "terminalNodeText": [
           "is"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "text": "value",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 5,
                         "terminalNodeText": [
                           "value"
                         ],
@@ -2895,15 +3669,21 @@
           },
           {
             "type": "TypeSpecifier",
+            "start": 9,
+            "end": 15,
             "terminalNodeText": [],
             "text": "string",
             "children": [
               {
                 "type": "QualifiedIdentifier",
+                "start": 9,
+                "end": 15,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 9,
+                    "end": 15,
                     "terminalNodeText": [
                       "string"
                     ],
@@ -2921,25 +3701,35 @@
     "children": [
       {
         "type": "TypeExpression",
+        "start": 0,
+        "end": 15,
         "terminalNodeText": [
           "as"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "text": "value",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 5,
                         "terminalNodeText": [
                           "value"
                         ],
@@ -2953,15 +3743,21 @@
           },
           {
             "type": "TypeSpecifier",
+            "start": 9,
+            "end": 15,
             "terminalNodeText": [],
             "text": "string",
             "children": [
               {
                 "type": "QualifiedIdentifier",
+                "start": 9,
+                "end": 15,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 9,
+                    "end": 15,
                     "terminalNodeText": [
                       "string"
                     ],
@@ -2979,25 +3775,35 @@
     "children": [
       {
         "type": "TypeExpression",
+        "start": 0,
+        "end": 20,
         "terminalNodeText": [
           "is"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "text": "value",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 5,
                         "terminalNodeText": [
                           "value"
                         ],
@@ -3011,17 +3817,23 @@
           },
           {
             "type": "TypeSpecifier",
+            "start": 9,
+            "end": 20,
             "terminalNodeText": [],
             "text": "FHIR.string",
             "children": [
               {
                 "type": "QualifiedIdentifier",
+                "start": 9,
+                "end": 20,
                 "terminalNodeText": [
                   "."
                 ],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 9,
+                    "end": 13,
                     "terminalNodeText": [
                       "FHIR"
                     ],
@@ -3029,6 +3841,8 @@
                   },
                   {
                     "type": "Identifier",
+                    "start": 14,
+                    "end": 20,
                     "terminalNodeText": [
                       "string"
                     ],
@@ -3046,25 +3860,35 @@
     "children": [
       {
         "type": "EqualityExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "="
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3078,19 +3902,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3110,25 +3942,35 @@
     "children": [
       {
         "type": "EqualityExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "!="
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3142,19 +3984,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3174,25 +4024,35 @@
     "children": [
       {
         "type": "EqualityExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [
           "~"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3206,19 +4066,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 4,
+            "end": 5,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3238,25 +4106,35 @@
     "children": [
       {
         "type": "EqualityExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "!~"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3270,19 +4148,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3302,25 +4188,35 @@
     "children": [
       {
         "type": "EqualityExpression",
+        "start": 0,
+        "end": 13,
         "terminalNodeText": [
           "="
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 4,
             "terminalNodeText": [],
             "text": "name",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [
                           "name"
                         ],
@@ -3334,16 +4230,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 7,
+            "end": 13,
             "terminalNodeText": [],
             "text": "'John'",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 7,
+                "end": 13,
                 "terminalNodeText": [],
                 "text": "'John'",
                 "children": [
                   {
                     "type": "StringLiteral",
+                    "start": 7,
+                    "end": 13,
                     "terminalNodeText": [
                       "'John'"
                     ],
@@ -3361,25 +4263,35 @@
     "children": [
       {
         "type": "MembershipExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "in"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3393,19 +4305,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3425,25 +4345,35 @@
     "children": [
       {
         "type": "MembershipExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [
           "contains"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3457,19 +4387,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 11,
+            "end": 12,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 11,
+                "end": 12,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 11,
+                    "end": 12,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 11,
+                        "end": 12,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3489,25 +4427,35 @@
     "children": [
       {
         "type": "AndExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "and"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3521,19 +4469,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 6,
+            "end": 7,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 6,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 6,
+                        "end": 7,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3553,25 +4509,35 @@
     "children": [
       {
         "type": "OrExpression",
+        "start": 0,
+        "end": 6,
         "terminalNodeText": [
           "or"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3585,19 +4551,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 5,
+            "end": 6,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3617,25 +4591,35 @@
     "children": [
       {
         "type": "OrExpression",
+        "start": 0,
+        "end": 7,
         "terminalNodeText": [
           "xor"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3649,19 +4633,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 6,
+            "end": 7,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 6,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 6,
+                        "end": 7,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3681,25 +4673,35 @@
     "children": [
       {
         "type": "ImpliesExpression",
+        "start": 0,
+        "end": 11,
         "terminalNodeText": [
           "implies"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -3713,19 +4715,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 10,
+            "end": 11,
             "terminalNodeText": [],
             "text": "b",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 10,
+                "end": 11,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 10,
+                    "end": 11,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 10,
+                        "end": 11,
                         "terminalNodeText": [
                           "b"
                         ],
@@ -3745,31 +4755,43 @@
     "children": [
       {
         "type": "AndExpression",
+        "start": 0,
+        "end": 13,
         "terminalNodeText": [
           "and"
         ],
         "children": [
           {
             "type": "AndExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [
               "and"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "a",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [
                               "a"
                             ],
@@ -3783,19 +4805,27 @@
               },
               {
                 "type": "TermExpression",
+                "start": 6,
+                "end": 7,
                 "terminalNodeText": [],
                 "text": "b",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 6,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 6,
+                        "end": 7,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 6,
+                            "end": 7,
                             "terminalNodeText": [
                               "b"
                             ],
@@ -3811,19 +4841,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 12,
+            "end": 13,
             "terminalNodeText": [],
             "text": "c",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 12,
+                "end": 13,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 12,
+                    "end": 13,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 12,
+                        "end": 13,
                         "terminalNodeText": [
                           "c"
                         ],
@@ -3843,31 +4881,43 @@
     "children": [
       {
         "type": "OrExpression",
+        "start": 0,
+        "end": 11,
         "terminalNodeText": [
           "or"
         ],
         "children": [
           {
             "type": "OrExpression",
+            "start": 0,
+            "end": 6,
             "terminalNodeText": [
               "or"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "text": "a",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 1,
                             "terminalNodeText": [
                               "a"
                             ],
@@ -3881,19 +4931,27 @@
               },
               {
                 "type": "TermExpression",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "b",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 5,
+                            "end": 6,
                             "terminalNodeText": [
                               "b"
                             ],
@@ -3909,19 +4967,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 10,
+            "end": 11,
             "terminalNodeText": [],
             "text": "c",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 10,
+                "end": 11,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 10,
+                    "end": 11,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 10,
+                        "end": 11,
                         "terminalNodeText": [
                           "c"
                         ],
@@ -3941,17 +5007,23 @@
     "children": [
       {
         "type": "MultiplicativeExpression",
+        "start": 0,
+        "end": 11,
         "terminalNodeText": [
           "*"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "(a+b)",
             "children": [
               {
                 "type": "ParenthesizedTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -3959,25 +5031,35 @@
                 "children": [
                   {
                     "type": "AdditiveExpression",
+                    "start": 1,
+                    "end": 6,
                     "terminalNodeText": [
                       "+"
                     ],
                     "children": [
                       {
                         "type": "TermExpression",
+                        "start": 1,
+                        "end": 2,
                         "terminalNodeText": [],
                         "text": "a",
                         "children": [
                           {
                             "type": "InvocationTerm",
+                            "start": 1,
+                            "end": 2,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "MemberInvocation",
+                                "start": 1,
+                                "end": 2,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "Identifier",
+                                    "start": 1,
+                                    "end": 2,
                                     "terminalNodeText": [
                                       "a"
                                     ],
@@ -3991,19 +5073,27 @@
                       },
                       {
                         "type": "TermExpression",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [],
                         "text": "b",
                         "children": [
                           {
                             "type": "InvocationTerm",
+                            "start": 5,
+                            "end": 6,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "MemberInvocation",
+                                "start": 5,
+                                "end": 6,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "Identifier",
+                                    "start": 5,
+                                    "end": 6,
                                     "terminalNodeText": [
                                       "b"
                                     ],
@@ -4023,19 +5113,27 @@
           },
           {
             "type": "TermExpression",
+            "start": 10,
+            "end": 11,
             "terminalNodeText": [],
             "text": "c",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 10,
+                "end": 11,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 10,
+                    "end": 11,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 10,
+                        "end": 11,
                         "terminalNodeText": [
                           "c"
                         ],
@@ -4055,25 +5153,35 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 9,
         "terminalNodeText": [
           "+"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -4087,25 +5195,35 @@
           },
           {
             "type": "MultiplicativeExpression",
+            "start": 4,
+            "end": 9,
             "terminalNodeText": [
               "*"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 4,
+                "end": 5,
                 "terminalNodeText": [],
                 "text": "b",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 4,
+                    "end": 5,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 4,
+                        "end": 5,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 4,
+                            "end": 5,
                             "terminalNodeText": [
                               "b"
                             ],
@@ -4119,19 +5237,27 @@
               },
               {
                 "type": "TermExpression",
+                "start": 8,
+                "end": 9,
                 "terminalNodeText": [],
                 "text": "c",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 8,
+                    "end": 9,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 8,
+                        "end": 9,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 8,
+                            "end": 9,
                             "terminalNodeText": [
                               "c"
                             ],
@@ -4153,25 +5279,35 @@
     "children": [
       {
         "type": "OrExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [
           "or"
         ],
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -4185,25 +5321,35 @@
           },
           {
             "type": "AndExpression",
+            "start": 5,
+            "end": 12,
             "terminalNodeText": [
               "and"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 5,
+                "end": 6,
                 "terminalNodeText": [],
                 "text": "b",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 5,
+                    "end": 6,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 5,
+                        "end": 6,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 5,
+                            "end": 6,
                             "terminalNodeText": [
                               "b"
                             ],
@@ -4217,19 +5363,27 @@
               },
               {
                 "type": "TermExpression",
+                "start": 11,
+                "end": 12,
                 "terminalNodeText": [],
                 "text": "c",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 11,
+                    "end": 12,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 11,
+                        "end": 12,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 11,
+                            "end": 12,
                             "terminalNodeText": [
                               "c"
                             ],
@@ -4251,6 +5405,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 50,
         "terminalNodeText": [
           "."
         ],
@@ -4258,6 +5414,8 @@
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 42,
             "terminalNodeText": [
               "."
             ],
@@ -4265,6 +5423,8 @@
             "children": [
               {
                 "type": "InvocationExpression",
+                "start": 0,
+                "end": 36,
                 "terminalNodeText": [
                   "."
                 ],
@@ -4272,6 +5432,8 @@
                 "children": [
                   {
                     "type": "InvocationExpression",
+                    "start": 0,
+                    "end": 12,
                     "terminalNodeText": [
                       "."
                     ],
@@ -4279,19 +5441,27 @@
                     "children": [
                       {
                         "type": "TermExpression",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [],
                         "text": "Patient",
                         "children": [
                           {
                             "type": "InvocationTerm",
+                            "start": 0,
+                            "end": 7,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "MemberInvocation",
+                                "start": 0,
+                                "end": 7,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "Identifier",
+                                    "start": 0,
+                                    "end": 7,
                                     "terminalNodeText": [
                                       "Patient"
                                     ],
@@ -4305,10 +5475,14 @@
                       },
                       {
                         "type": "MemberInvocation",
+                        "start": 8,
+                        "end": 12,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 8,
+                            "end": 12,
                             "terminalNodeText": [
                               "name"
                             ],
@@ -4320,10 +5494,14 @@
                   },
                   {
                     "type": "FunctionInvocation",
+                    "start": 13,
+                    "end": 36,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Functn",
+                        "start": 13,
+                        "end": 36,
                         "terminalNodeText": [
                           "(",
                           ")"
@@ -4331,6 +5509,8 @@
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 13,
+                            "end": 18,
                             "terminalNodeText": [
                               "where"
                             ],
@@ -4338,29 +5518,41 @@
                           },
                           {
                             "type": "ParamList",
+                            "start": 19,
+                            "end": 35,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "EqualityExpression",
+                                "start": 19,
+                                "end": 35,
                                 "terminalNodeText": [
                                   "="
                                 ],
                                 "children": [
                                   {
                                     "type": "TermExpression",
+                                    "start": 19,
+                                    "end": 22,
                                     "terminalNodeText": [],
                                     "text": "use",
                                     "children": [
                                       {
                                         "type": "InvocationTerm",
+                                        "start": 19,
+                                        "end": 22,
                                         "terminalNodeText": [],
                                         "children": [
                                           {
                                             "type": "MemberInvocation",
+                                            "start": 19,
+                                            "end": 22,
                                             "terminalNodeText": [],
                                             "children": [
                                               {
                                                 "type": "Identifier",
+                                                "start": 19,
+                                                "end": 22,
                                                 "terminalNodeText": [
                                                   "use"
                                                 ],
@@ -4374,16 +5566,22 @@
                                   },
                                   {
                                     "type": "TermExpression",
+                                    "start": 25,
+                                    "end": 35,
                                     "terminalNodeText": [],
                                     "text": "'official'",
                                     "children": [
                                       {
                                         "type": "LiteralTerm",
+                                        "start": 25,
+                                        "end": 35,
                                         "terminalNodeText": [],
                                         "text": "'official'",
                                         "children": [
                                           {
                                             "type": "StringLiteral",
+                                            "start": 25,
+                                            "end": 35,
                                             "terminalNodeText": [
                                               "'official'"
                                             ],
@@ -4405,10 +5603,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 37,
+                "end": 42,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 37,
+                    "end": 42,
                     "terminalNodeText": [
                       "given"
                     ],
@@ -4420,10 +5622,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 43,
+            "end": 50,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 43,
+                "end": 50,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -4431,6 +5637,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 43,
+                    "end": 48,
                     "terminalNodeText": [
                       "first"
                     ],
@@ -4448,12 +5656,16 @@
     "children": [
       {
         "type": "AndExpression",
+        "start": 0,
+        "end": 26,
         "terminalNodeText": [
           "and"
         ],
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 13,
             "terminalNodeText": [
               "."
             ],
@@ -4461,19 +5673,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 4,
                 "terminalNodeText": [],
                 "text": "name",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 4,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 4,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 4,
                             "terminalNodeText": [
                               "name"
                             ],
@@ -4487,10 +5707,14 @@
               },
               {
                 "type": "FunctionInvocation",
+                "start": 5,
+                "end": 13,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Functn",
+                    "start": 5,
+                    "end": 13,
                     "terminalNodeText": [
                       "(",
                       ")"
@@ -4498,6 +5722,8 @@
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 5,
+                        "end": 11,
                         "terminalNodeText": [
                           "exists"
                         ],
@@ -4511,25 +5737,35 @@
           },
           {
             "type": "InequalityExpression",
+            "start": 18,
+            "end": 26,
             "terminalNodeText": [
               ">"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 18,
+                "end": 21,
                 "terminalNodeText": [],
                 "text": "age",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 18,
+                    "end": 21,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 18,
+                        "end": 21,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 18,
+                            "end": 21,
                             "terminalNodeText": [
                               "age"
                             ],
@@ -4543,16 +5779,22 @@
               },
               {
                 "type": "TermExpression",
+                "start": 24,
+                "end": 26,
                 "terminalNodeText": [],
                 "text": "18",
                 "children": [
                   {
                     "type": "LiteralTerm",
+                    "start": 24,
+                    "end": 26,
                     "terminalNodeText": [],
                     "text": "18",
                     "children": [
                       {
                         "type": "NumberLiteral",
+                        "start": 24,
+                        "end": 26,
                         "terminalNodeText": [
                           "18"
                         ],
@@ -4572,12 +5814,16 @@
     "children": [
       {
         "type": "UnionExpression",
+        "start": 0,
+        "end": 28,
         "terminalNodeText": [
           "|"
         ],
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 12,
             "terminalNodeText": [
               "."
             ],
@@ -4585,19 +5831,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "text": "Patient",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 0,
+                            "end": 7,
                             "terminalNodeText": [
                               "Patient"
                             ],
@@ -4611,10 +5865,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 8,
+                "end": 12,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 8,
+                    "end": 12,
                     "terminalNodeText": [
                       "name"
                     ],
@@ -4626,6 +5884,8 @@
           },
           {
             "type": "InvocationExpression",
+            "start": 15,
+            "end": 28,
             "terminalNodeText": [
               "."
             ],
@@ -4633,19 +5893,27 @@
             "children": [
               {
                 "type": "TermExpression",
+                "start": 15,
+                "end": 22,
                 "terminalNodeText": [],
                 "text": "Patient",
                 "children": [
                   {
                     "type": "InvocationTerm",
+                    "start": 15,
+                    "end": 22,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "MemberInvocation",
+                        "start": 15,
+                        "end": 22,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "Identifier",
+                            "start": 15,
+                            "end": 22,
                             "terminalNodeText": [
                               "Patient"
                             ],
@@ -4659,10 +5927,14 @@
               },
               {
                 "type": "MemberInvocation",
+                "start": 23,
+                "end": 28,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 23,
+                    "end": 28,
                     "terminalNodeText": [
                       "alias"
                     ],
@@ -4680,19 +5952,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 16,
         "terminalNodeText": [],
         "text": "iif(a>b,a,b)",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 16,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "FunctionInvocation",
+                "start": 0,
+                "end": 16,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Functn",
+                    "start": 0,
+                    "end": 16,
                     "terminalNodeText": [
                       "(",
                       ")"
@@ -4700,6 +5980,8 @@
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 3,
                         "terminalNodeText": [
                           "iif"
                         ],
@@ -4707,6 +5989,8 @@
                       },
                       {
                         "type": "ParamList",
+                        "start": 4,
+                        "end": 15,
                         "terminalNodeText": [
                           ",",
                           ","
@@ -4714,25 +5998,35 @@
                         "children": [
                           {
                             "type": "InequalityExpression",
+                            "start": 4,
+                            "end": 9,
                             "terminalNodeText": [
                               ">"
                             ],
                             "children": [
                               {
                                 "type": "TermExpression",
+                                "start": 4,
+                                "end": 5,
                                 "terminalNodeText": [],
                                 "text": "a",
                                 "children": [
                                   {
                                     "type": "InvocationTerm",
+                                    "start": 4,
+                                    "end": 5,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "MemberInvocation",
+                                        "start": 4,
+                                        "end": 5,
                                         "terminalNodeText": [],
                                         "children": [
                                           {
                                             "type": "Identifier",
+                                            "start": 4,
+                                            "end": 5,
                                             "terminalNodeText": [
                                               "a"
                                             ],
@@ -4746,19 +6040,27 @@
                               },
                               {
                                 "type": "TermExpression",
+                                "start": 8,
+                                "end": 9,
                                 "terminalNodeText": [],
                                 "text": "b",
                                 "children": [
                                   {
                                     "type": "InvocationTerm",
+                                    "start": 8,
+                                    "end": 9,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "MemberInvocation",
+                                        "start": 8,
+                                        "end": 9,
                                         "terminalNodeText": [],
                                         "children": [
                                           {
                                             "type": "Identifier",
+                                            "start": 8,
+                                            "end": 9,
                                             "terminalNodeText": [
                                               "b"
                                             ],
@@ -4774,19 +6076,27 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 11,
+                            "end": 12,
                             "terminalNodeText": [],
                             "text": "a",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 11,
+                                "end": 12,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 11,
+                                    "end": 12,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 11,
+                                        "end": 12,
                                         "terminalNodeText": [
                                           "a"
                                         ],
@@ -4800,19 +6110,27 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 14,
+                            "end": 15,
                             "terminalNodeText": [],
                             "text": "b",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 14,
+                                "end": 15,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 14,
+                                    "end": 15,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 14,
+                                        "end": 15,
                                         "terminalNodeText": [
                                           "b"
                                         ],
@@ -4840,6 +6158,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 12,
         "terminalNodeText": [
           "."
         ],
@@ -4847,21 +6167,29 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 9,
             "terminalNodeText": [],
             "text": "%resource",
             "children": [
               {
                 "type": "ExternalConstantTerm",
+                "start": 0,
+                "end": 9,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "ExternalConstant",
+                    "start": 0,
+                    "end": 9,
                     "terminalNodeText": [
                       "%"
                     ],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 1,
+                        "end": 9,
                         "terminalNodeText": [
                           "resource"
                         ],
@@ -4875,10 +6203,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 10,
+            "end": 12,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 10,
+                "end": 12,
                 "terminalNodeText": [
                   "id"
                 ],
@@ -4894,6 +6226,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 62,
         "terminalNodeText": [
           "."
         ],
@@ -4901,6 +6235,8 @@
         "children": [
           {
             "type": "InvocationExpression",
+            "start": 0,
+            "end": 56,
             "terminalNodeText": [
               "."
             ],
@@ -4908,6 +6244,8 @@
             "children": [
               {
                 "type": "InvocationExpression",
+                "start": 0,
+                "end": 21,
                 "terminalNodeText": [
                   "."
                 ],
@@ -4915,19 +6253,27 @@
                 "children": [
                   {
                     "type": "TermExpression",
+                    "start": 0,
+                    "end": 11,
                     "terminalNodeText": [],
                     "text": "Observation",
                     "children": [
                       {
                         "type": "InvocationTerm",
+                        "start": 0,
+                        "end": 11,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "MemberInvocation",
+                            "start": 0,
+                            "end": 11,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "Identifier",
+                                "start": 0,
+                                "end": 11,
                                 "terminalNodeText": [
                                   "Observation"
                                 ],
@@ -4941,10 +6287,14 @@
                   },
                   {
                     "type": "MemberInvocation",
+                    "start": 12,
+                    "end": 21,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 12,
+                        "end": 21,
                         "terminalNodeText": [
                           "component"
                         ],
@@ -4956,10 +6306,14 @@
               },
               {
                 "type": "FunctionInvocation",
+                "start": 22,
+                "end": 56,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Functn",
+                    "start": 22,
+                    "end": 56,
                     "terminalNodeText": [
                       "(",
                       ")"
@@ -4967,6 +6321,8 @@
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 22,
+                        "end": 27,
                         "terminalNodeText": [
                           "where"
                         ],
@@ -4974,16 +6330,22 @@
                       },
                       {
                         "type": "ParamList",
+                        "start": 28,
+                        "end": 55,
                         "terminalNodeText": [],
                         "children": [
                           {
                             "type": "EqualityExpression",
+                            "start": 28,
+                            "end": 55,
                             "terminalNodeText": [
                               "="
                             ],
                             "children": [
                               {
                                 "type": "InvocationExpression",
+                                "start": 28,
+                                "end": 44,
                                 "terminalNodeText": [
                                   "."
                                 ],
@@ -4991,6 +6353,8 @@
                                 "children": [
                                   {
                                     "type": "InvocationExpression",
+                                    "start": 28,
+                                    "end": 39,
                                     "terminalNodeText": [
                                       "."
                                     ],
@@ -4998,19 +6362,27 @@
                                     "children": [
                                       {
                                         "type": "TermExpression",
+                                        "start": 28,
+                                        "end": 32,
                                         "terminalNodeText": [],
                                         "text": "code",
                                         "children": [
                                           {
                                             "type": "InvocationTerm",
+                                            "start": 28,
+                                            "end": 32,
                                             "terminalNodeText": [],
                                             "children": [
                                               {
                                                 "type": "MemberInvocation",
+                                                "start": 28,
+                                                "end": 32,
                                                 "terminalNodeText": [],
                                                 "children": [
                                                   {
                                                     "type": "Identifier",
+                                                    "start": 28,
+                                                    "end": 32,
                                                     "terminalNodeText": [
                                                       "code"
                                                     ],
@@ -5024,10 +6396,14 @@
                                       },
                                       {
                                         "type": "MemberInvocation",
+                                        "start": 33,
+                                        "end": 39,
                                         "terminalNodeText": [],
                                         "children": [
                                           {
                                             "type": "Identifier",
+                                            "start": 33,
+                                            "end": 39,
                                             "terminalNodeText": [
                                               "coding"
                                             ],
@@ -5039,10 +6415,14 @@
                                   },
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 40,
+                                    "end": 44,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 40,
+                                        "end": 44,
                                         "terminalNodeText": [
                                           "code"
                                         ],
@@ -5054,16 +6434,22 @@
                               },
                               {
                                 "type": "TermExpression",
+                                "start": 47,
+                                "end": 55,
                                 "terminalNodeText": [],
                                 "text": "'8480-6'",
                                 "children": [
                                   {
                                     "type": "LiteralTerm",
+                                    "start": 47,
+                                    "end": 55,
                                     "terminalNodeText": [],
                                     "text": "'8480-6'",
                                     "children": [
                                       {
                                         "type": "StringLiteral",
+                                        "start": 47,
+                                        "end": 55,
                                         "terminalNodeText": [
                                           "'8480-6'"
                                         ],
@@ -5085,10 +6471,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 57,
+            "end": 62,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 57,
+                "end": 62,
                 "terminalNodeText": [
                   "value"
                 ],
@@ -5104,19 +6494,27 @@
     "children": [
       {
         "type": "TermExpression",
+        "start": 0,
+        "end": 5,
         "terminalNodeText": [],
         "text": "`div`",
         "children": [
           {
             "type": "InvocationTerm",
+            "start": 0,
+            "end": 5,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "MemberInvocation",
+                "start": 0,
+                "end": 5,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 0,
+                    "end": 5,
                     "terminalNodeText": [
                       "`div`"
                     ],
@@ -5134,28 +6532,38 @@
     "children": [
       {
         "type": "AdditiveExpression",
+        "start": 0,
+        "end": 23,
         "terminalNodeText": [
           "&"
         ],
         "children": [
           {
             "type": "AdditiveExpression",
+            "start": 0,
+            "end": 13,
             "terminalNodeText": [
               "&"
             ],
             "children": [
               {
                 "type": "TermExpression",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "text": "'hello'",
                 "children": [
                   {
                     "type": "LiteralTerm",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "text": "'hello'",
                     "children": [
                       {
                         "type": "StringLiteral",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "'hello'"
                         ],
@@ -5167,16 +6575,22 @@
               },
               {
                 "type": "TermExpression",
+                "start": 10,
+                "end": 13,
                 "terminalNodeText": [],
                 "text": "' '",
                 "children": [
                   {
                     "type": "LiteralTerm",
+                    "start": 10,
+                    "end": 13,
                     "terminalNodeText": [],
                     "text": "' '",
                     "children": [
                       {
                         "type": "StringLiteral",
+                        "start": 10,
+                        "end": 13,
                         "terminalNodeText": [
                           "' '"
                         ],
@@ -5190,16 +6604,22 @@
           },
           {
             "type": "TermExpression",
+            "start": 16,
+            "end": 23,
             "terminalNodeText": [],
             "text": "'world'",
             "children": [
               {
                 "type": "LiteralTerm",
+                "start": 16,
+                "end": 23,
                 "terminalNodeText": [],
                 "text": "'world'",
                 "children": [
                   {
                     "type": "StringLiteral",
+                    "start": 16,
+                    "end": 23,
                     "terminalNodeText": [
                       "'world'"
                     ],
@@ -5217,6 +6637,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 19,
         "terminalNodeText": [
           "."
         ],
@@ -5224,19 +6646,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -5250,10 +6680,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 2,
+            "end": 19,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 2,
+                "end": 19,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -5261,6 +6695,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 2,
+                    "end": 7,
                     "terminalNodeText": [
                       "where"
                     ],
@@ -5268,10 +6704,14 @@
                   },
                   {
                     "type": "ParamList",
+                    "start": 8,
+                    "end": 18,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "InvocationExpression",
+                        "start": 8,
+                        "end": 18,
                         "terminalNodeText": [
                           "."
                         ],
@@ -5279,19 +6719,27 @@
                         "children": [
                           {
                             "type": "TermExpression",
+                            "start": 8,
+                            "end": 9,
                             "terminalNodeText": [],
                             "text": "b",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 8,
+                                "end": 9,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 8,
+                                    "end": 9,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 8,
+                                        "end": 9,
                                         "terminalNodeText": [
                                           "b"
                                         ],
@@ -5305,10 +6753,14 @@
                           },
                           {
                             "type": "FunctionInvocation",
+                            "start": 10,
+                            "end": 18,
                             "terminalNodeText": [],
                             "children": [
                               {
                                 "type": "Functn",
+                                "start": 10,
+                                "end": 18,
                                 "terminalNodeText": [
                                   "(",
                                   ")"
@@ -5316,6 +6768,8 @@
                                 "children": [
                                   {
                                     "type": "Identifier",
+                                    "start": 10,
+                                    "end": 16,
                                     "terminalNodeText": [
                                       "exists"
                                     ],
@@ -5341,6 +6795,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 15,
         "terminalNodeText": [
           "."
         ],
@@ -5348,19 +6804,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 1,
             "terminalNodeText": [],
             "text": "a",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 1,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 1,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 1,
                         "terminalNodeText": [
                           "a"
                         ],
@@ -5374,10 +6838,14 @@
           },
           {
             "type": "FunctionInvocation",
+            "start": 2,
+            "end": 15,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Functn",
+                "start": 2,
+                "end": 15,
                 "terminalNodeText": [
                   "(",
                   ")"
@@ -5385,6 +6853,8 @@
                 "children": [
                   {
                     "type": "Identifier",
+                    "start": 2,
+                    "end": 8,
                     "terminalNodeText": [
                       "select"
                     ],
@@ -5392,29 +6862,41 @@
                   },
                   {
                     "type": "ParamList",
+                    "start": 9,
+                    "end": 14,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "AdditiveExpression",
+                        "start": 9,
+                        "end": 14,
                         "terminalNodeText": [
                           "+"
                         ],
                         "children": [
                           {
                             "type": "TermExpression",
+                            "start": 9,
+                            "end": 10,
                             "terminalNodeText": [],
                             "text": "b",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 9,
+                                "end": 10,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 9,
+                                    "end": 10,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 9,
+                                        "end": 10,
                                         "terminalNodeText": [
                                           "b"
                                         ],
@@ -5428,19 +6910,27 @@
                           },
                           {
                             "type": "TermExpression",
+                            "start": 13,
+                            "end": 14,
                             "terminalNodeText": [],
                             "text": "c",
                             "children": [
                               {
                                 "type": "InvocationTerm",
+                                "start": 13,
+                                "end": 14,
                                 "terminalNodeText": [],
                                 "children": [
                                   {
                                     "type": "MemberInvocation",
+                                    "start": 13,
+                                    "end": 14,
                                     "terminalNodeText": [],
                                     "children": [
                                       {
                                         "type": "Identifier",
+                                        "start": 13,
+                                        "end": 14,
                                         "terminalNodeText": [
                                           "c"
                                         ],
@@ -5468,6 +6958,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 10,
         "terminalNodeText": [
           "."
         ],
@@ -5475,19 +6967,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "Patient",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "Patient"
                         ],
@@ -5501,10 +7001,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 8,
+            "end": 10,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 8,
+                "end": 10,
                 "terminalNodeText": [
                   "as"
                 ],
@@ -5520,6 +7024,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 10,
         "terminalNodeText": [
           "."
         ],
@@ -5527,19 +7033,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "Patient",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "Patient"
                         ],
@@ -5553,10 +7067,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 8,
+            "end": 10,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 8,
+                "end": 10,
                 "terminalNodeText": [
                   "is"
                 ],
@@ -5572,6 +7090,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 16,
         "terminalNodeText": [
           "."
         ],
@@ -5579,19 +7099,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "Patient",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "Patient"
                         ],
@@ -5605,10 +7133,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 8,
+            "end": 16,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 8,
+                "end": 16,
                 "terminalNodeText": [
                   "contains"
                 ],
@@ -5624,6 +7156,8 @@
     "children": [
       {
         "type": "InvocationExpression",
+        "start": 0,
+        "end": 10,
         "terminalNodeText": [
           "."
         ],
@@ -5631,19 +7165,27 @@
         "children": [
           {
             "type": "TermExpression",
+            "start": 0,
+            "end": 7,
             "terminalNodeText": [],
             "text": "Patient",
             "children": [
               {
                 "type": "InvocationTerm",
+                "start": 0,
+                "end": 7,
                 "terminalNodeText": [],
                 "children": [
                   {
                     "type": "MemberInvocation",
+                    "start": 0,
+                    "end": 7,
                     "terminalNodeText": [],
                     "children": [
                       {
                         "type": "Identifier",
+                        "start": 0,
+                        "end": 7,
                         "terminalNodeText": [
                           "Patient"
                         ],
@@ -5657,10 +7199,14 @@
           },
           {
             "type": "MemberInvocation",
+            "start": 8,
+            "end": 10,
             "terminalNodeText": [],
             "children": [
               {
                 "type": "Identifier",
+                "start": 8,
+                "end": 10,
                 "terminalNodeText": [
                   "in"
                 ],


### PR DESCRIPTION
Closes #5

## Summary

- Adds `byte_start`/`byte_end` to `Token` in `src/lexer.rs`, tracked via a `char_to_byte` mapping built upfront from `input.char_indices()` — correct for non-ASCII input where char index ≠ byte offset
- Adds `byte_start`/`byte_end` to `AstNode` in `src/parser.rs`, derived from the token byte ranges at parse time via an updated `AstNode::new(node_type, token_start, tokens)` signature
- Exposes `start`/`end` fields in the PyO3 dict output (`src/lib.rs`)
- Regenerates all golden AST fixtures in `tests/fixtures/ast/` to include the new fields

## Test plan

- [ ] `cargo test` passes
- [ ] `uv run pytest tests/` passes (1718 tests)
- [ ] `parse("item.where(linkId='x')")` returns nodes with correct `start`/`end` byte offsets
- [ ] For `"item"` in `"item.where(linkId='x')"`: `start=0, end=4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)