### PR TITLE
Feature-flag PyO3, expose public Rust API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,9 @@ edition = "2021"
 name = "_rust"
 crate-type = ["cdylib"]
 
+[features]
+default = ["python"]
+python = ["dep:pyo3"]
+
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
+pyo3 = { version = "0.25", features = ["extension-module"], optional = true }

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "python")]
+pub mod python;

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "python")]
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+use crate::lexer::Token;
+use crate::AstNode;
+
+/// Parse a FHIRPath expression string into an AST dict.
+#[pyfunction]
+fn parse(py: Python<'_>, expr: &str) -> PyResult<PyObject> {
+    let (ast, tokens) = rust_parse_with_tokens(expr)
+        .map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e.0))?;
+
+    // Build root dict: { "children": [top_expression] }
+    let root = PyDict::new(py);
+    let children = PyList::new(py, [ast_to_pydict(py, &ast, &tokens)?])?;
+    root.set_item("children", children)?;
+    Ok(root.into())
+}
+
+fn ast_to_pydict(py: Python<'_>, node: &AstNode, tokens: &[Token]) -> PyResult<PyObject> {
+    let dict = PyDict::new(py);
+
+    // type
+    dict.set_item("type", node.node_type)?;
+
+    // byte offsets into the source string
+    dict.set_item("start", node.byte_start)?;
+    dict.set_item("end", node.byte_end)?;
+
+    // terminalNodeText
+    let tnt = PyList::new(
+        py,
+        node.terminal_node_text
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+    dict.set_item("terminalNodeText", tnt)?;
+
+    // text — only for certain node types
+    if has_text_field(node.node_type) {
+        let text = compute_text(node, tokens);
+        dict.set_item("text", text)?;
+    }
+
+    // children — only when non-empty
+    if !node.children.is_empty() {
+        let children: Vec<PyObject> = node
+            .children
+            .iter()
+            .map(|child| ast_to_pydict(py, child, tokens))
+            .collect::<PyResult<Vec<_>>>()?;
+        let children_list = PyList::new(py, children)?;
+        dict.set_item("children", children_list)?;
+    }
+
+    Ok(dict.into())
+}
+
+fn has_text_field(node_type: &str) -> bool {
+    node_type.ends_with("Literal")
+        || node_type == "LiteralTerm"
+        || node_type == "Identifier"
+        || node_type == "TypeSpecifier"
+        || node_type == "InvocationExpression"
+        || node_type == "TermExpression"
+}
+
+fn compute_text(node: &AstNode, tokens: &[Token]) -> String {
+    // Concatenate token text for tokens in [token_start..token_end)
+    let mut s = String::new();
+    for i in node.token_start..node.token_end {
+        s.push_str(&tokens[i].text);
+    }
+    s
+}
+
+#[pymodule]
+pub fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("IMPLEMENTED", true)?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
+    Ok(())
+}
+
+/// Internal helper: parse and also return the token stream (needed for text computation).
+fn rust_parse_with_tokens(expr: &str) -> Result<(AstNode, Vec<Token>), crate::ParseError> {
+    let tokens = crate::lexer::tokenize(expr).map_err(crate::ParseError)?;
+    let mut p = crate::parser::Parser::new(&tokens);
+    let ast = p.parse_entire_expression().map_err(crate::ParseError)?;
+    Ok((ast, tokens))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,89 +1,32 @@
-mod lexer;
-mod parser;
+pub mod bindings;
+pub mod lexer;
+pub mod parser;
 
-use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+pub use lexer::{Token, TokenKind};
+pub use parser::AstNode;
 
-use crate::lexer::tokenize;
-use crate::parser::{AstNode, Parser};
+use lexer::tokenize;
+use parser::Parser;
 
-/// Parse a FHIRPath expression string into an AST dict.
-#[pyfunction]
-fn parse(py: Python<'_>, expr: &str) -> PyResult<PyObject> {
-    let tokens = tokenize(expr).map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e))?;
+/// Parse error type.
+#[derive(Debug)]
+pub struct ParseError(pub String);
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FHIRPath parse error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse a FHIRPath expression string into an AST.
+pub fn parse(expr: &str) -> Result<AstNode, ParseError> {
+    let tokens = tokenize(expr).map_err(ParseError)?;
     let mut p = Parser::new(&tokens);
-    let ast = p
-        .parse_entire_expression()
-        .map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e))?;
-
-    // Build root dict: { "children": [top_expression] }
-    let root = PyDict::new(py);
-    let children = PyList::new(py, [ast_to_pydict(py, &ast, &tokens)?])?;
-    root.set_item("children", children)?;
-    Ok(root.into())
+    p.parse_entire_expression().map_err(ParseError)
 }
 
-fn ast_to_pydict(py: Python<'_>, node: &AstNode, tokens: &[lexer::Token]) -> PyResult<PyObject> {
-    let dict = PyDict::new(py);
-
-    // type
-    dict.set_item("type", node.node_type)?;
-
-    // byte offsets into the source string
-    dict.set_item("start", node.byte_start)?;
-    dict.set_item("end", node.byte_end)?;
-
-    // terminalNodeText
-    let tnt = PyList::new(
-        py,
-        node.terminal_node_text
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<_>>(),
-    )?;
-    dict.set_item("terminalNodeText", tnt)?;
-
-    // text — only for certain node types
-    if has_text_field(node.node_type) {
-        let text = compute_text(node, tokens);
-        dict.set_item("text", text)?;
-    }
-
-    // children — only when non-empty
-    if !node.children.is_empty() {
-        let children: Vec<PyObject> = node
-            .children
-            .iter()
-            .map(|child| ast_to_pydict(py, child, tokens))
-            .collect::<PyResult<Vec<_>>>()?;
-        let children_list = PyList::new(py, children)?;
-        dict.set_item("children", children_list)?;
-    }
-
-    Ok(dict.into())
-}
-
-fn has_text_field(node_type: &str) -> bool {
-    node_type.ends_with("Literal")
-        || node_type == "LiteralTerm"
-        || node_type == "Identifier"
-        || node_type == "TypeSpecifier"
-        || node_type == "InvocationExpression"
-        || node_type == "TermExpression"
-}
-
-fn compute_text(node: &AstNode, tokens: &[lexer::Token]) -> String {
-    // Concatenate token text for tokens in [token_start..token_end)
-    let mut s = String::new();
-    for i in node.token_start..node.token_end {
-        s.push_str(&tokens[i].text);
-    }
-    s
-}
-
-#[pymodule]
-fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("IMPLEMENTED", true)?;
-    m.add_function(wrap_pyfunction!(parse, m)?)?;
-    Ok(())
-}
+// Re-export the PyO3 module entry point when the python feature is enabled.
+#[cfg(feature = "python")]
+pub use bindings::python::_rust;


### PR DESCRIPTION
Closes #6

## Summary

- Makes `pyo3` optional behind a `python` feature flag (`default = ["python"]`) in `Cargo.toml` — `cargo check --no-default-features` now compiles without any PyO3 dependency
- Moves all PyO3 bindings into `src/bindings/python.rs` (gated with `#![cfg(feature = "python")]`)
- Adds `src/bindings/mod.rs` as the bindings module router
- Rewrites `src/lib.rs` as a clean public Rust API: exports `parse()`, `AstNode`, `Token`, `TokenKind`, `ParseError`

## Test plan

- [ ] `cargo check --no-default-features` succeeds
- [ ] `cargo check` (default features) succeeds
- [ ] `maturin develop --uv && uv run pytest tests/` passes (1718 tests)
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)