### PR TITLE
QuestionnaireIndex in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,8 @@ name = "fhirpathrs"
 version = "2.1.0"
 dependencies = [
  "pyo3",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -31,10 +33,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -144,6 +158,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,3 +228,9 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ python = ["dep:pyo3"]
 
 [dependencies]
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -1,0 +1,2 @@
+pub mod questionnaire_index;
+pub use questionnaire_index::QuestionnaireIndex;

--- a/src/analyze/questionnaire_index.rs
+++ b/src/analyze/questionnaire_index.rs
@@ -5,7 +5,7 @@ pub struct QuestionnaireItemInfo {
     pub link_id: String,
     pub text: String,
     pub item_type: String,
-    pub answer_options: HashMap<String, String>, // code -> display
+    pub answer_options: HashMap<(String, String), String>, // (system, code) -> display
     pub parent_link_id: Option<String>,
     pub children: Vec<String>,
 }
@@ -36,11 +36,15 @@ impl QuestionnaireIndex {
             let mut answer_options = HashMap::new();
             if let Some(opts) = item.get("answerOption").and_then(|v| v.as_array()) {
                 for opt in opts {
-                    if let (Some(code), Some(display)) = (
+                    if let (Some(system), Some(code), Some(display)) = (
+                        opt.pointer("/valueCoding/system").and_then(|v| v.as_str()),
                         opt.pointer("/valueCoding/code").and_then(|v| v.as_str()),
                         opt.pointer("/valueCoding/display").and_then(|v| v.as_str()),
                     ) {
-                        answer_options.insert(code.to_string(), display.to_string());
+                        answer_options.insert(
+                            (system.to_string(), code.to_string()),
+                            display.to_string(),
+                        );
                     }
                 }
             }
@@ -93,11 +97,11 @@ impl QuestionnaireIndex {
         self.items.get(link_id).map(|i| i.text.as_str())
     }
 
-    pub fn resolve_code_display(&self, link_id: &str, code: &str) -> Option<&str> {
+    pub fn resolve_code_display(&self, link_id: &str, system: &str, code: &str) -> Option<&str> {
         self.items
             .get(link_id)?
             .answer_options
-            .get(code)
+            .get(&(system.to_string(), code.to_string()))
             .map(|s| s.as_str())
     }
 
@@ -182,10 +186,11 @@ mod tests {
     #[test]
     fn test_resolve_code_display() {
         let idx = QuestionnaireIndex::build(&sample_questionnaire());
-        assert_eq!(idx.resolve_code_display("choice1", "A"), Some("Alpha"));
-        assert_eq!(idx.resolve_code_display("choice1", "B"), Some("Beta"));
-        assert_eq!(idx.resolve_code_display("choice1", "C"), None);
-        assert_eq!(idx.resolve_code_display("bool1", "A"), None);
+        assert_eq!(idx.resolve_code_display("choice1", "http://example.com", "A"), Some("Alpha"));
+        assert_eq!(idx.resolve_code_display("choice1", "http://example.com", "B"), Some("Beta"));
+        assert_eq!(idx.resolve_code_display("choice1", "http://example.com", "C"), None);
+        assert_eq!(idx.resolve_code_display("choice1", "http://other.com", "A"), None);
+        assert_eq!(idx.resolve_code_display("bool1", "http://example.com", "A"), None);
     }
 
     #[test]

--- a/src/analyze/questionnaire_index.rs
+++ b/src/analyze/questionnaire_index.rs
@@ -1,0 +1,233 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct QuestionnaireItemInfo {
+    pub link_id: String,
+    pub text: String,
+    pub item_type: String,
+    pub answer_options: HashMap<String, String>, // code -> display
+    pub parent_link_id: Option<String>,
+    pub children: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct QuestionnaireIndex {
+    items: HashMap<String, QuestionnaireItemInfo>,
+}
+
+impl QuestionnaireIndex {
+    /// Build index from a FHIR Questionnaire JSON value.
+    /// Expects `questionnaire["item"]` to be an array of item objects.
+    pub fn build(questionnaire: &serde_json::Value) -> Self {
+        let mut index = Self::default();
+        if let Some(items) = questionnaire.get("item").and_then(|v| v.as_array()) {
+            index.walk(items, None);
+        }
+        index
+    }
+
+    fn walk(&mut self, items: &[serde_json::Value], parent_link_id: Option<&str>) {
+        for item in items {
+            let Some(link_id) = item.get("linkId").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let link_id = link_id.to_string();
+
+            let mut answer_options = HashMap::new();
+            if let Some(opts) = item.get("answerOption").and_then(|v| v.as_array()) {
+                for opt in opts {
+                    if let (Some(code), Some(display)) = (
+                        opt.pointer("/valueCoding/code").and_then(|v| v.as_str()),
+                        opt.pointer("/valueCoding/display").and_then(|v| v.as_str()),
+                    ) {
+                        answer_options.insert(code.to_string(), display.to_string());
+                    }
+                }
+            }
+
+            let text = item
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&link_id)
+                .to_string();
+            let item_type = item
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("group")
+                .to_string();
+
+            self.items.insert(
+                link_id.clone(),
+                QuestionnaireItemInfo {
+                    link_id: link_id.clone(),
+                    text,
+                    item_type,
+                    answer_options,
+                    parent_link_id: parent_link_id.map(|s| s.to_string()),
+                    children: Vec::new(),
+                },
+            );
+
+            // Update parent's children vec
+            if let Some(pid) = parent_link_id {
+                if let Some(parent) = self.items.get_mut(pid) {
+                    parent.children.push(link_id.clone());
+                }
+            }
+
+            if let Some(sub_items) = item.get("item").and_then(|v| v.as_array()) {
+                self.walk(sub_items, Some(&link_id));
+            }
+        }
+    }
+
+    pub fn get(&self, link_id: &str) -> Option<&QuestionnaireItemInfo> {
+        self.items.get(link_id)
+    }
+
+    pub fn contains(&self, link_id: &str) -> bool {
+        self.items.contains_key(link_id)
+    }
+
+    pub fn resolve_item_text(&self, link_id: &str) -> Option<&str> {
+        self.items.get(link_id).map(|i| i.text.as_str())
+    }
+
+    pub fn resolve_code_display(&self, link_id: &str, code: &str) -> Option<&str> {
+        self.items
+            .get(link_id)?
+            .answer_options
+            .get(code)
+            .map(|s| s.as_str())
+    }
+
+    pub fn resolve_item_type(&self, link_id: &str) -> Option<&str> {
+        self.items.get(link_id).map(|i| i.item_type.as_str())
+    }
+
+    /// Check if `descendant` is a child/grandchild/... of `ancestor`.
+    pub fn is_descendant(&self, ancestor: &str, descendant: &str) -> bool {
+        let mut current = descendant;
+        for _ in 0..100 {
+            // depth limit for safety
+            match self
+                .items
+                .get(current)
+                .and_then(|i| i.parent_link_id.as_deref())
+            {
+                Some(p) if p == ancestor => return true,
+                Some(p) => current = p,
+                None => return false,
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_questionnaire() -> serde_json::Value {
+        json!({
+            "resourceType": "Questionnaire",
+            "item": [
+                {
+                    "linkId": "group1",
+                    "text": "Group One",
+                    "type": "group",
+                    "item": [
+                        {
+                            "linkId": "choice1",
+                            "text": "Pick one",
+                            "type": "choice",
+                            "answerOption": [
+                                { "valueCoding": { "system": "http://example.com", "code": "A", "display": "Alpha" } },
+                                { "valueCoding": { "system": "http://example.com", "code": "B", "display": "Beta" } }
+                            ]
+                        },
+                        {
+                            "linkId": "bool1",
+                            "text": "Yes or no",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "string1",
+                    "text": "Free text",
+                    "type": "string"
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_resolve_text() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        assert_eq!(idx.resolve_item_text("group1"), Some("Group One"));
+        assert_eq!(idx.resolve_item_text("choice1"), Some("Pick one"));
+        assert_eq!(idx.resolve_item_text("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_resolve_type() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        assert_eq!(idx.resolve_item_type("group1"), Some("group"));
+        assert_eq!(idx.resolve_item_type("choice1"), Some("choice"));
+        assert_eq!(idx.resolve_item_type("bool1"), Some("boolean"));
+    }
+
+    #[test]
+    fn test_resolve_code_display() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        assert_eq!(idx.resolve_code_display("choice1", "A"), Some("Alpha"));
+        assert_eq!(idx.resolve_code_display("choice1", "B"), Some("Beta"));
+        assert_eq!(idx.resolve_code_display("choice1", "C"), None);
+        assert_eq!(idx.resolve_code_display("bool1", "A"), None);
+    }
+
+    #[test]
+    fn test_contains() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        assert!(idx.contains("group1"));
+        assert!(!idx.contains("ghost"));
+    }
+
+    #[test]
+    fn test_parent_child() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let group = idx.get("group1").unwrap();
+        assert_eq!(group.parent_link_id, None);
+        assert!(group.children.contains(&"choice1".to_string()));
+        assert!(group.children.contains(&"bool1".to_string()));
+
+        let choice = idx.get("choice1").unwrap();
+        assert_eq!(choice.parent_link_id.as_deref(), Some("group1"));
+    }
+
+    #[test]
+    fn test_is_descendant() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        assert!(idx.is_descendant("group1", "choice1"));
+        assert!(idx.is_descendant("group1", "bool1"));
+        assert!(!idx.is_descendant("string1", "choice1"));
+        assert!(!idx.is_descendant("choice1", "group1"));
+        assert!(!idx.is_descendant("group1", "group1"));
+    }
+
+    #[test]
+    fn test_text_fallback_to_link_id() {
+        let q = json!({"resourceType": "Questionnaire", "item": [{"linkId": "no-text", "type": "string"}]});
+        let idx = QuestionnaireIndex::build(&q);
+        assert_eq!(idx.resolve_item_text("no-text"), Some("no-text"));
+    }
+
+    #[test]
+    fn test_type_fallback_to_group() {
+        let q = json!({"resourceType": "Questionnaire", "item": [{"linkId": "no-type"}]});
+        let idx = QuestionnaireIndex::build(&q);
+        assert_eq!(idx.resolve_item_type("no-type"), Some("group"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analyze;
 pub mod bindings;
 pub mod lexer;
 pub mod parser;


### PR DESCRIPTION
Closes #8

## Summary

- Adds `serde` and `serde_json` as dependencies in `Cargo.toml`
- Adds `src/analyze/questionnaire_index.rs` implementing `QuestionnaireIndex`:
  - `build(questionnaire: &Value)` — recursively walks Questionnaire JSON `item[]` arrays
  - `resolve_item_text(link_id)` — text lookup with fallback to linkId
  - `resolve_item_type(link_id)` — type lookup with fallback to "group"
  - `resolve_code_display(link_id, code)` — answer option display from `answerOption[].valueCoding`
  - `is_descendant(ancestor, descendant)` — walks parent chain for reachability checks
  - `contains(link_id)`, `get(link_id)` — basic lookups
- 8 unit tests covering text/type/code resolution, parent-child relationships, descendant checks, and fallback behavior

## Test plan

- [ ] `cargo test` passes (8 new tests)
- [ ] `maturin develop --uv && pytest tests/` passes (1718 existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)