### PR TITLE
LinkId validation

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -10,20 +10,21 @@ use super::{Annotation, AnnotationKind, Span, ValueAccessor};
 
 // ── Helper types ────────────────────────────────────────────────────────
 
-enum ChainStepKind {
+pub(crate) enum ChainStepKind {
     Identifier(String),
     Function { name: String, link_id: Option<String> },
     External,
 }
 
-struct ChainStep {
-    kind: ChainStepKind,
+pub(crate) struct ChainStep {
+    pub(crate) kind: ChainStepKind,
+    pub(crate) link_id_span: Option<Span>,
 }
 
 // ── Helper functions ────────────────────────────────────────────────────
 
 /// If `node` is an Identifier, return its name.
-fn get_identifier_name(node: &AstNode) -> Option<&str> {
+pub(crate) fn get_identifier_name(node: &AstNode) -> Option<&str> {
     if node.node_type == "Identifier" {
         node.terminal_node_text.first().map(|s| s.as_str())
     } else {
@@ -54,7 +55,8 @@ fn extract_string_value(node: &AstNode) -> Option<String> {
 
 /// Extract a linkId from a `where(linkId='...')` call.
 /// `functn` is the `Functn` node inside a `FunctionInvocation`.
-fn extract_link_id_from_where(functn: &AstNode) -> Option<String> {
+/// Returns the linkId string value and the byte span of the string literal.
+pub(crate) fn extract_link_id_from_where(functn: &AstNode) -> Option<(String, Span)> {
     // Functn.children: [Identifier("where"), ParamList]
     let name_node = functn.children.first()?;
     if get_identifier_name(name_node)? != "where" {
@@ -81,7 +83,26 @@ fn extract_link_id_from_where(functn: &AstNode) -> Option<String> {
         return None;
     }
 
-    extract_string_value(right)
+    // Navigate to the StringLiteral node to get its byte span
+    let string_node = find_string_literal_node(right)?;
+    let value = extract_string_value(right)?;
+    Some((value, Span { start: string_node.byte_start, end: string_node.byte_end }))
+}
+
+/// Navigate through TermExpression -> LiteralTerm -> StringLiteral to find the StringLiteral node.
+fn find_string_literal_node(node: &AstNode) -> Option<&AstNode> {
+    let mut current = node;
+    if current.node_type == "TermExpression" {
+        current = current.children.first()?;
+    }
+    if current.node_type == "LiteralTerm" {
+        current = current.children.first()?;
+    }
+    if current.node_type == "StringLiteral" {
+        Some(current)
+    } else {
+        None
+    }
 }
 
 /// Navigate TermExpression -> InvocationTerm -> MemberInvocation -> Identifier to get the name.
@@ -100,7 +121,7 @@ fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
 }
 
 /// Recursively flatten an InvocationExpression tree into a chain of steps.
-fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
+pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
     match node.node_type {
         "TermExpression" => {
             let inner = node.children.first()?;
@@ -112,6 +133,7 @@ fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                         let name = get_identifier_name(ident)?.to_string();
                         Some(vec![ChainStep {
                             kind: ChainStepKind::Identifier(name),
+                            link_id_span: None,
                         }])
                     } else {
                         None
@@ -126,6 +148,7 @@ fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                     let _name = get_identifier_name(ident)?;
                     Some(vec![ChainStep {
                         kind: ChainStepKind::External,
+                        link_id_span: None,
                     }])
                 }
                 _ => None,
@@ -143,6 +166,7 @@ fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                     let name = get_identifier_name(ident)?.to_string();
                     steps.push(ChainStep {
                         kind: ChainStepKind::Identifier(name),
+                        link_id_span: None,
                     });
                 }
                 "FunctionInvocation" => {
@@ -152,16 +176,20 @@ fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                     }
                     let func_ident = functn.children.first()?;
                     let func_name = get_identifier_name(func_ident)?.to_string();
-                    let link_id = if func_name == "where" {
-                        extract_link_id_from_where(functn)
+                    let (link_id, link_id_span) = if func_name == "where" {
+                        match extract_link_id_from_where(functn) {
+                            Some((id, span)) => (Some(id), Some(span)),
+                            None => (None, None),
+                        }
                     } else {
-                        None
+                        (None, None)
                     };
                     steps.push(ChainStep {
                         kind: ChainStepKind::Function {
                             name: func_name,
                             link_id,
                         },
+                        link_id_span,
                     });
                 }
                 _ => return None,

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -39,8 +39,31 @@ pub struct Annotation {
     pub kind: AnnotationKind,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiagnosticCode {
+    UnknownLinkId,
+    UnreachableLinkId,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub span: Span,
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+}
+
 pub mod annotations;
 pub use annotations::annotate_expression;
 
 pub mod questionnaire_index;
 pub use questionnaire_index::QuestionnaireIndex;
+
+pub mod validate_link_ids;
+pub use validate_link_ids::validate_link_ids;

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -1,0 +1,211 @@
+use crate::analyze::annotations::{decompose_chain, ChainStepKind};
+use crate::analyze::questionnaire_index::QuestionnaireIndex;
+use crate::analyze::{Diagnostic, DiagnosticCode, Severity, Span};
+use crate::parser::AstNode;
+
+/// Collect all linkIds referenced in where(linkId='...') clauses throughout the AST.
+/// Returns Vec of (linkId_value, span_of_the_literal).
+fn collect_link_id_references(node: &AstNode) -> Vec<(String, Span)> {
+    let mut refs = Vec::new();
+    collect_link_ids_recursive(node, &mut refs);
+    refs
+}
+
+fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
+    // Try to decompose this node as a chain and extract linkIds from where() steps
+    if node.node_type == "InvocationExpression" || node.node_type == "TermExpression" {
+        if let Some(steps) = decompose_chain(node) {
+            for step in &steps {
+                if let ChainStepKind::Function {
+                    name,
+                    link_id: Some(id),
+                } = &step.kind
+                {
+                    if name == "where" {
+                        if let Some(span) = &step.link_id_span {
+                            out.push((id.clone(), span.clone()));
+                        }
+                    }
+                }
+            }
+            // Skip recursing into children — the chain decomposition from the outermost
+            // node already captures all linkIds, and inner InvocationExpression nodes
+            // would produce duplicates.
+            return;
+        }
+    }
+
+    // Recurse into children
+    for child in &node.children {
+        collect_link_ids_recursive(child, out);
+    }
+}
+
+/// Validate linkIds in FHIRPath where() clauses against a QuestionnaireIndex.
+///
+/// Checks:
+/// - Each linkId exists in the Questionnaire (`UnknownLinkId`)
+/// - If `context_link_id` is provided, each linkId is reachable from context (`UnreachableLinkId`)
+pub fn validate_link_ids(
+    expr: &str,
+    index: &QuestionnaireIndex,
+    context_link_id: Option<&str>,
+) -> Result<Vec<Diagnostic>, crate::ParseError> {
+    let tokens = crate::lexer::tokenize(expr).map_err(crate::ParseError)?;
+    let mut parser = crate::parser::Parser::new(&tokens);
+    let root = parser.parse_entire_expression().map_err(crate::ParseError)?;
+
+    let refs = collect_link_id_references(&root);
+    let mut diagnostics = Vec::new();
+
+    for (link_id, span) in &refs {
+        if !index.contains(link_id) {
+            diagnostics.push(Diagnostic {
+                span: span.clone(),
+                severity: Severity::Error,
+                code: DiagnosticCode::UnknownLinkId,
+                message: format!("Unknown linkId '{}'", link_id),
+            });
+        } else if let Some(ctx) = context_link_id {
+            if !index.is_descendant(ctx, link_id) && link_id != ctx {
+                diagnostics.push(Diagnostic {
+                    span: span.clone(),
+                    severity: Severity::Warning,
+                    code: DiagnosticCode::UnreachableLinkId,
+                    message: format!(
+                        "linkId '{}' is not reachable from context '{}'",
+                        link_id, ctx
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(diagnostics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyze::questionnaire_index::QuestionnaireIndex;
+    use serde_json::json;
+
+    fn sample_questionnaire() -> serde_json::Value {
+        json!({
+            "resourceType": "Questionnaire",
+            "item": [
+                {
+                    "linkId": "group1",
+                    "text": "Group One",
+                    "type": "group",
+                    "item": [
+                        {
+                            "linkId": "choice1",
+                            "text": "Pick one",
+                            "type": "choice"
+                        },
+                        {
+                            "linkId": "bool1",
+                            "text": "Yes or no",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "string1",
+                    "text": "Free text",
+                    "type": "string"
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_unknown_link_id() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids("item.where(linkId='typo').answer.value", &idx, None).unwrap();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::UnknownLinkId);
+        assert!(diags[0].message.contains("typo"));
+    }
+
+    #[test]
+    fn test_valid_link_id_no_diagnostic() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags =
+            validate_link_ids("item.where(linkId='choice1').answer.value", &idx, None).unwrap();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_unreachable_link_id() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids(
+            "item.where(linkId='choice1').answer.value",
+            &idx,
+            Some("string1"), // choice1 is not a descendant of string1
+        )
+        .unwrap();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::UnreachableLinkId);
+    }
+
+    #[test]
+    fn test_reachable_link_id_no_diagnostic() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids(
+            "item.where(linkId='choice1').answer.value",
+            &idx,
+            Some("group1"), // choice1 IS a descendant of group1
+        )
+        .unwrap();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_nested_link_ids_both_checked() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids(
+            "item.where(linkId='group1').item.where(linkId='nonexistent').answer.value",
+            &idx,
+            None,
+        )
+        .unwrap();
+        // group1 is valid, nonexistent is not
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::UnknownLinkId);
+        assert!(diags[0].message.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_diagnostic_span_points_at_literal() {
+        let expr = "item.where(linkId='typo').answer.value";
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids(expr, &idx, None).unwrap();
+        assert_eq!(diags.len(), 1);
+        // The span should cover the string literal 'typo' (including quotes)
+        // — verify it's within the where() clause, not the whole expr
+        assert!(diags[0].span.start > 0);
+        assert!(diags[0].span.end < expr.len());
+    }
+
+    #[test]
+    fn test_context_link_id_is_self() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        // Referencing the context itself should be ok
+        let diags = validate_link_ids(
+            "item.where(linkId='group1').answer.value",
+            &idx,
+            Some("group1"),
+        )
+        .unwrap();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_no_where_clauses() {
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids("Patient.name.given", &idx, None).unwrap();
+        assert!(diags.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #9

## Summary

- Makes annotation internals (`decompose_chain`, `ChainStep`, `extract_link_id_from_where`, etc.) `pub(crate)` for reuse by validation modules
- Extends `extract_link_id_from_where` to return `(String, Span)` — the linkId value plus the byte span of the string literal, enabling precise diagnostic positioning
- Adds `Severity`, `DiagnosticCode`, `Diagnostic` types to `src/analyze/mod.rs`
- Adds `src/analyze/validate_link_ids.rs`:
  - `validate_link_ids(expr, index, context_link_id)` — parses expression, collects all `where(linkId='...')` references, checks each against the QuestionnaireIndex
  - `UnknownLinkId` error when linkId doesn't exist in Questionnaire
  - `UnreachableLinkId` warning when linkId exists but isn't reachable from context
  - Diagnostic spans point at the linkId string literal, not the whole expression

## Test plan

- [ ] `cargo test` passes (26 tests: 18 existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)