### PR TITLE
Expose analysis API via PyO3

### DIFF
--- a/fhirpathrs/__init__.py
+++ b/fhirpathrs/__init__.py
@@ -3,6 +3,11 @@ from fhirpathrs.parser import parse
 from fhirpathrs.engine import do_eval
 from fhirpathrs.engine.util import arraify, get_data, set_paths, process_user_invocation_table
 from fhirpathrs.engine.nodes import FP_Type, ResourceNode
+from fhirpathrs._rust import (
+    annotate_expression,
+    analyze_expression,
+    QuestionnaireIndex,
+)
 
 __title__ = "fhirpathrs"
 __version__ = "2.1.0"

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -3,6 +3,9 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
+use crate::analyze::{
+    self, AnnotationKind, DiagnosticCode, Severity, ValueAccessor,
+};
 use crate::lexer::Token;
 use crate::AstNode;
 
@@ -77,10 +80,166 @@ fn compute_text(node: &AstNode, tokens: &[Token]) -> String {
     s
 }
 
+// ── QuestionnaireIndex wrapper ──────────────────────────────────────────
+
+#[pyclass(name = "QuestionnaireIndex")]
+struct PyQuestionnaireIndex {
+    inner: analyze::QuestionnaireIndex,
+}
+
+#[pymethods]
+impl PyQuestionnaireIndex {
+    #[new]
+    fn new(questionnaire_json: &str) -> PyResult<Self> {
+        let value: serde_json::Value = serde_json::from_str(questionnaire_json)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self {
+            inner: analyze::QuestionnaireIndex::build(&value),
+        })
+    }
+
+    fn resolve_item_text(&self, link_id: &str) -> Option<String> {
+        self.inner.resolve_item_text(link_id).map(|s| s.to_string())
+    }
+
+    fn resolve_code_display(&self, link_id: &str, system: &str, code: &str) -> Option<String> {
+        self.inner
+            .resolve_code_display(link_id, system, code)
+            .map(|s| s.to_string())
+    }
+
+    fn contains(&self, link_id: &str) -> bool {
+        self.inner.contains(link_id)
+    }
+}
+
+// ── Annotation / analysis helpers ──────────────────────────────────────
+
+fn accessor_to_str(accessor: &ValueAccessor) -> &'static str {
+    match accessor {
+        ValueAccessor::Value => "value",
+        ValueAccessor::Code => "code",
+        ValueAccessor::Display => "display",
+    }
+}
+
+fn severity_to_str(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+fn diagnostic_code_to_str(code: &DiagnosticCode) -> &'static str {
+    match code {
+        DiagnosticCode::UnknownLinkId => "unknown_link_id",
+        DiagnosticCode::UnreachableLinkId => "unreachable_link_id",
+        DiagnosticCode::InvalidAccessorForType => "invalid_accessor_for_type",
+        DiagnosticCode::MissingAccessorForCoding => "missing_accessor_for_coding",
+        DiagnosticCode::ItemReferenceTargetsLeaf => "item_reference_targets_leaf",
+        DiagnosticCode::ContextUnreachableFromParent => "context_unreachable_from_parent",
+    }
+}
+
+fn annotation_to_pydict(py: Python<'_>, ann: &analyze::Annotation) -> PyResult<PyObject> {
+    let dict = PyDict::new(py);
+    dict.set_item("start", ann.span.start)?;
+    dict.set_item("end", ann.span.end)?;
+    match &ann.kind {
+        AnnotationKind::AnswerReference { link_ids, accessor } => {
+            dict.set_item("kind", "answer_reference")?;
+            let ids = PyList::new(py, link_ids.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+            dict.set_item("link_ids", ids)?;
+            dict.set_item("accessor", accessor_to_str(accessor))?;
+        }
+        AnnotationKind::ItemReference { link_ids } => {
+            dict.set_item("kind", "item_reference")?;
+            let ids = PyList::new(py, link_ids.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+            dict.set_item("link_ids", ids)?;
+        }
+        AnnotationKind::CodedValue {
+            code,
+            system,
+            context_link_id,
+        } => {
+            dict.set_item("kind", "coded_value")?;
+            dict.set_item("code", code.as_str())?;
+            match system {
+                Some(s) => dict.set_item("system", s.as_str())?,
+                None => dict.set_item("system", py.None())?,
+            }
+            dict.set_item("context_link_id", context_link_id.as_str())?;
+        }
+    }
+    Ok(dict.into())
+}
+
+fn diagnostic_to_pydict(py: Python<'_>, diag: &analyze::Diagnostic) -> PyResult<PyObject> {
+    let dict = PyDict::new(py);
+    dict.set_item("severity", severity_to_str(&diag.severity))?;
+    dict.set_item("code", diagnostic_code_to_str(&diag.code))?;
+    dict.set_item("message", diag.message.as_str())?;
+    dict.set_item("start", diag.span.start)?;
+    dict.set_item("end", diag.span.end)?;
+    Ok(dict.into())
+}
+
+// ── Python-facing functions ────────────────────────────────────────────
+
+/// Annotate a FHIRPath expression, returning a list of annotation dicts.
+#[pyfunction]
+fn annotate_expression(py: Python<'_>, expr: &str) -> PyResult<PyObject> {
+    let annotations = analyze::annotate_expression(expr)
+        .map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e.0))?;
+    let result: Vec<PyObject> = annotations
+        .iter()
+        .map(|a| annotation_to_pydict(py, a))
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok(PyList::new(py, result)?.into())
+}
+
+/// Analyze a FHIRPath expression against a QuestionnaireIndex, returning
+/// annotations and diagnostics.
+#[pyfunction]
+#[pyo3(signature = (expr, index, context_link_id=None, parent_context_expr=None))]
+fn analyze_expression(
+    py: Python<'_>,
+    expr: &str,
+    index: &PyQuestionnaireIndex,
+    context_link_id: Option<&str>,
+    parent_context_expr: Option<&str>,
+) -> PyResult<PyObject> {
+    let context = analyze::AnalysisContext {
+        scope_link_id: context_link_id.map(|s| s.to_string()),
+        parent_context_expr: parent_context_expr.map(|s| s.to_string()),
+    };
+    let result = analyze::analyze_expression(expr, &index.inner, &context)
+        .map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e.0))?;
+
+    let annotations: Vec<PyObject> = result
+        .annotations
+        .iter()
+        .map(|a| annotation_to_pydict(py, a))
+        .collect::<PyResult<Vec<_>>>()?;
+    let diagnostics: Vec<PyObject> = result
+        .diagnostics
+        .iter()
+        .map(|d| diagnostic_to_pydict(py, d))
+        .collect::<PyResult<Vec<_>>>()?;
+
+    let dict = PyDict::new(py);
+    dict.set_item("annotations", PyList::new(py, annotations)?)?;
+    dict.set_item("diagnostics", PyList::new(py, diagnostics)?)?;
+    Ok(dict.into())
+}
+
 #[pymodule]
 pub fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("IMPLEMENTED", true)?;
     m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_class::<PyQuestionnaireIndex>()?;
+    m.add_function(wrap_pyfunction!(annotate_expression, m)?)?;
+    m.add_function(wrap_pyfunction!(analyze_expression, m)?)?;
     Ok(())
 }
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,255 @@
+"""Integration tests for the analysis API exposed via PyO3."""
+
+import json
+
+import pytest
+
+from fhirpathrs import annotate_expression, analyze_expression, QuestionnaireIndex
+
+
+QUESTIONNAIRE_JSON = json.dumps(
+    {
+        "resourceType": "Questionnaire",
+        "item": [
+            {
+                "linkId": "group1",
+                "text": "Group One",
+                "type": "group",
+                "item": [
+                    {
+                        "linkId": "choice1",
+                        "text": "Pick one",
+                        "type": "choice",
+                        "answerOption": [
+                            {
+                                "valueCoding": {
+                                    "system": "http://example.com",
+                                    "code": "A",
+                                    "display": "Alpha",
+                                }
+                            },
+                            {
+                                "valueCoding": {
+                                    "system": "http://example.com",
+                                    "code": "B",
+                                    "display": "Beta",
+                                }
+                            },
+                        ],
+                    },
+                    {"linkId": "bool1", "text": "Yes or no", "type": "boolean"},
+                    {
+                        "linkId": "subgroup",
+                        "type": "group",
+                        "item": [{"linkId": "deep", "type": "string"}],
+                    },
+                ],
+            },
+            {
+                "linkId": "group2",
+                "type": "group",
+                "item": [{"linkId": "other", "type": "decimal"}],
+            },
+        ],
+    }
+)
+
+
+# ── Import smoke test ──────────────────────────────────────────────────
+
+
+def imports_test():
+    """All analysis symbols are importable from the top-level package."""
+    from fhirpathrs import annotate_expression, analyze_expression, QuestionnaireIndex  # noqa: F811
+
+    assert callable(annotate_expression)
+    assert callable(analyze_expression)
+    assert QuestionnaireIndex is not None
+
+
+# ── QuestionnaireIndex ─────────────────────────────────────────────────
+
+
+def questionnaire_index_construction_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    assert idx.contains("group1")
+    assert idx.contains("choice1")
+    assert not idx.contains("nonexistent")
+
+
+def questionnaire_index_resolve_item_text_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    assert idx.resolve_item_text("group1") == "Group One"
+    assert idx.resolve_item_text("choice1") == "Pick one"
+    assert idx.resolve_item_text("nonexistent") is None
+
+
+def questionnaire_index_resolve_code_display_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    assert idx.resolve_code_display("choice1", "http://example.com", "A") == "Alpha"
+    assert idx.resolve_code_display("choice1", "http://example.com", "B") == "Beta"
+    assert idx.resolve_code_display("choice1", "http://example.com", "C") is None
+    assert idx.resolve_code_display("bool1", "http://example.com", "A") is None
+
+
+def questionnaire_index_invalid_json_test():
+    with pytest.raises(ValueError):
+        QuestionnaireIndex("not valid json")
+
+
+# ── annotate_expression ────────────────────────────────────────────────
+
+
+def annotate_answer_reference_test():
+    result = annotate_expression("item.where(linkId='x').answer.value.code")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "answer_reference"
+    assert ann["link_ids"] == ["x"]
+    assert ann["accessor"] == "code"
+    assert ann["start"] == 0
+    assert ann["end"] == len("item.where(linkId='x').answer.value.code")
+
+
+def annotate_item_reference_test():
+    result = annotate_expression("item.where(linkId='group1')")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "item_reference"
+    assert ann["link_ids"] == ["group1"]
+
+
+def annotate_coded_value_test():
+    result = annotate_expression("item.where(linkId='x').answer.value.code = 'yes'")
+    assert len(result) == 2
+    kinds = {a["kind"] for a in result}
+    assert "answer_reference" in kinds
+    assert "coded_value" in kinds
+    coded = next(a for a in result if a["kind"] == "coded_value")
+    assert coded["code"] == "yes"
+    assert coded["system"] is None
+    assert coded["context_link_id"] == "x"
+
+
+def annotate_factory_coding_test():
+    expr = "item.where(linkId='x').answer.value ~ %factory.Coding('http://snomed.info/sct', '373067005')"
+    result = annotate_expression(expr)
+    coded = next(a for a in result if a["kind"] == "coded_value")
+    assert coded["code"] == "373067005"
+    assert coded["system"] == "http://snomed.info/sct"
+
+
+def annotate_non_qr_expression_test():
+    result = annotate_expression("Patient.name.given")
+    assert result == []
+
+
+def annotate_nested_item_navigation_test():
+    result = annotate_expression(
+        "item.where(linkId='a').item.where(linkId='b').answer.value.code"
+    )
+    assert len(result) == 1
+    assert result[0]["link_ids"] == ["a", "b"]
+    assert result[0]["accessor"] == "code"
+
+
+def annotate_value_accessor_test():
+    bare = annotate_expression("item.where(linkId='x').answer.value")
+    assert bare[0]["accessor"] == "value"
+
+    display = annotate_expression("item.where(linkId='x').answer.value.display")
+    assert display[0]["accessor"] == "display"
+
+
+def annotate_syntax_error_test():
+    with pytest.raises(SyntaxError):
+        annotate_expression("!")
+
+
+# ── analyze_expression ─────────────────────────────────────────────────
+
+
+def analyze_clean_expression_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("item.where(linkId='choice1').answer.value.code", idx)
+    assert isinstance(result, dict)
+    assert "annotations" in result
+    assert "diagnostics" in result
+    assert len(result["annotations"]) > 0
+    assert len(result["diagnostics"]) == 0
+
+
+def analyze_unknown_link_id_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("item.where(linkId='typo').answer.value", idx)
+    diags = result["diagnostics"]
+    assert any(d["code"] == "unknown_link_id" for d in diags)
+    diag = next(d for d in diags if d["code"] == "unknown_link_id")
+    assert diag["severity"] == "error"
+    assert isinstance(diag["message"], str)
+    assert isinstance(diag["start"], int)
+    assert isinstance(diag["end"], int)
+
+
+def analyze_unreachable_link_id_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='other').answer.value",
+        idx,
+        context_link_id="group1",
+    )
+    diags = result["diagnostics"]
+    assert any(d["code"] == "unreachable_link_id" for d in diags)
+
+
+def analyze_invalid_accessor_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("item.where(linkId='bool1').answer.value.code", idx)
+    diags = result["diagnostics"]
+    assert any(d["code"] == "invalid_accessor_for_type" for d in diags)
+
+
+def analyze_non_qr_expression_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("Patient.name.given", idx)
+    assert result["annotations"] == []
+    assert result["diagnostics"] == []
+
+
+def analyze_with_parent_context_unreachable_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='group2')",
+        idx,
+        parent_context_expr="%resource.item.where(linkId='group1')",
+    )
+    diags = result["diagnostics"]
+    assert any(d["code"] == "context_unreachable_from_parent" for d in diags)
+
+
+def analyze_with_parent_context_reachable_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='subgroup')",
+        idx,
+        parent_context_expr="%resource.item.where(linkId='group1')",
+    )
+    diags = result["diagnostics"]
+    assert not any(d["code"] == "context_unreachable_from_parent" for d in diags)
+
+
+def analyze_item_reference_targets_leaf_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='group1').item.where(linkId='bool1')",
+        idx,
+    )
+    diags = result["diagnostics"]
+    assert any(d["code"] == "item_reference_targets_leaf" for d in diags)
+
+
+def analyze_syntax_error_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    with pytest.raises(SyntaxError):
+        analyze_expression("!", idx)


### PR DESCRIPTION
## Summary
- Add `PyQuestionnaireIndex`, `annotate_expression()`, and `analyze_expression()` to PyO3 bindings
- Re-export from `fhirpathrs/__init__.py` so `from fhirpathrs import annotate_expression, analyze_expression, QuestionnaireIndex` works
- 22 new Python integration tests covering all annotation kinds, diagnostics, and error paths

Closes #12

## Test plan
- [x] `cargo test` — 54 Rust tests pass
- [x] `pytest` — 1740 Python tests pass (22 new)
- [ ] Verify imports work in downstream report-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)