### PR TITLE
Add wasm-bindgen target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,9 @@ jobs:
       run: uv python install ${{ matrix.python-version }}
     - name: Install dependencies
       run: uv sync --extra test
-    - name: Run tests
+    - name: Run Rust tests
+      run: cargo test --no-default-features
+    - name: Run Python tests
       run: uv run pytest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
@@ -40,3 +42,25 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         verbose: true
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    - name: Build WASM
+      run: wasm-pack build --target web --features wasm --no-default-features
+    - name: Overlay custom package metadata and types
+      run: |
+        cp wasm/package.json pkg/package.json
+        cp wasm/fhirpath_wasm.d.ts pkg/fhirpath_wasm.d.ts
+    - name: Upload WASM artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: wasm-pkg
+        path: pkg/

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ docs/_build/
 # Rust / Cargo build artifacts
 target/
 
+# wasm-pack build output
+pkg/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "fhirpathrs"
 version = "2.1.0"
 dependencies = [
  "pyo3",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -37,6 +51,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -168,6 +192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +263,51 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,16 @@ edition = "2021"
 
 [lib]
 name = "_rust"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["python"]
 python = ["dep:pyo3"]
+wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen"]
 
 [dependencies]
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+wasm-bindgen = { version = "0.2", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -6,13 +6,14 @@
 
 // ── Core types ──────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Span {
     pub start: usize,
     pub end: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ValueAccessor {
     /// `.answer.value` (bare)
     Value,
@@ -22,7 +23,8 @@ pub enum ValueAccessor {
     Display,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnnotationKind {
     /// Path navigating to a QR answer value.
     AnswerReference {
@@ -39,19 +41,21 @@ pub enum AnnotationKind {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Annotation {
     pub span: Span,
     pub kind: AnnotationKind,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Severity {
     Error,
     Warning,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DiagnosticCode {
     UnknownLinkId,
     UnreachableLinkId,
@@ -61,7 +65,7 @@ pub enum DiagnosticCode {
     ContextUnreachableFromParent,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Diagnostic {
     pub span: Span,
     pub severity: Severity,
@@ -86,7 +90,7 @@ pub struct AnalysisContext {
 }
 
 /// Result of analyzing a FHIRPath expression.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct ExpressionAnalysis {
     pub annotations: Vec<Annotation>,
     pub diagnostics: Vec<Diagnostic>,

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "python")]
 pub mod python;
+
+#[cfg(feature = "wasm")]
+pub mod wasm;

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -1,0 +1,71 @@
+#![cfg(feature = "wasm")]
+
+use wasm_bindgen::prelude::*;
+
+use crate::analyze;
+
+/// Parse a FHIRPath expression string into an AST.
+///
+/// Returns the AST as a JavaScript object.
+#[wasm_bindgen]
+pub fn parse(expr: &str) -> Result<JsValue, JsError> {
+    let ast = crate::parse(expr).map_err(|e| JsError::new(&e.0))?;
+    serde_wasm_bindgen::to_value(&ast).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Annotate a FHIRPath expression, extracting answer references,
+/// item references, and coded values.
+///
+/// Returns `Annotation[]` as a JavaScript value.
+#[wasm_bindgen]
+pub fn annotate_expression(expr: &str) -> Result<JsValue, JsError> {
+    let annotations =
+        analyze::annotate_expression(expr).map_err(|e| JsError::new(&e.to_string()))?;
+    serde_wasm_bindgen::to_value(&annotations).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// A Questionnaire index for use in expression analysis.
+///
+/// Build one from a FHIR Questionnaire JSON string, then pass it
+/// to `analyze_expression` for semantic validation.
+#[wasm_bindgen]
+pub struct QuestionnaireIndex {
+    inner: analyze::QuestionnaireIndex,
+}
+
+#[wasm_bindgen]
+impl QuestionnaireIndex {
+    /// Build a `QuestionnaireIndex` from a FHIR Questionnaire JSON string.
+    #[wasm_bindgen(constructor)]
+    pub fn new(questionnaire_json: &str) -> Result<QuestionnaireIndex, JsError> {
+        let value: serde_json::Value = serde_json::from_str(questionnaire_json)
+            .map_err(|e| JsError::new(&format!("Invalid JSON: {e}")))?;
+        Ok(QuestionnaireIndex {
+            inner: analyze::QuestionnaireIndex::build(&value),
+        })
+    }
+}
+
+/// Analyze a FHIRPath expression in the context of a Questionnaire.
+///
+/// Returns `{ annotations: Annotation[], diagnostics: Diagnostic[] }`.
+///
+/// - `expr` -- the FHIRPath expression string
+/// - `index` -- a `QuestionnaireIndex` built from the Questionnaire
+/// - `scope_link_id` -- optional linkId of the item scope (for reachability checks)
+/// - `parent_context_expr` -- optional parent context expression (raw FHIRPath)
+#[wasm_bindgen]
+pub fn analyze_expression(
+    expr: &str,
+    index: &QuestionnaireIndex,
+    scope_link_id: Option<String>,
+    parent_context_expr: Option<String>,
+) -> Result<JsValue, JsError> {
+    let context = analyze::AnalysisContext {
+        scope_link_id,
+        parent_context_expr,
+    };
+    let result = analyze::analyze_expression(expr, &index.inner, &context)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@
 
 use crate::lexer::{Token, TokenKind};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct AstNode {
     pub node_type: &'static str,
     pub terminal_node_text: Vec<String>,

--- a/wasm/fhirpath_wasm.d.ts
+++ b/wasm/fhirpath_wasm.d.ts
@@ -1,0 +1,80 @@
+/** Byte offset range within the original FHIRPath expression string. */
+export interface Span {
+  start: number;
+  end: number;
+}
+
+export type AnnotationKind =
+  | {
+      type: "answer_reference";
+      link_ids: string[];
+      accessor: "value" | "code" | "display";
+    }
+  | { type: "item_reference"; link_ids: string[] }
+  | {
+      type: "coded_value";
+      code: string;
+      system?: string;
+      context_link_id: string;
+    };
+
+export interface Annotation {
+  span: Span;
+  kind: AnnotationKind;
+}
+
+export interface Diagnostic {
+  span: Span;
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+}
+
+export interface AnalysisResult {
+  annotations: Annotation[];
+  diagnostics: Diagnostic[];
+}
+
+/** Parse a FHIRPath expression string into an AST object. */
+export function parse(expr: string): object;
+
+/** Annotate a FHIRPath expression, extracting answer/item references and coded values. */
+export function annotate_expression(expr: string): Annotation[];
+
+/** Index built from a FHIR Questionnaire, used for expression analysis. */
+export class QuestionnaireIndex {
+  constructor(questionnaire_json: string);
+}
+
+/**
+ * Analyze a FHIRPath expression in the context of a Questionnaire.
+ *
+ * Returns annotations and validation diagnostics.
+ */
+export function analyze_expression(
+  expr: string,
+  index: QuestionnaireIndex,
+  scope_link_id?: string,
+  parent_context_expr?: string,
+): AnalysisResult;
+
+export type InitInput =
+  | RequestInfo
+  | URL
+  | Response
+  | BufferSource
+  | WebAssembly.Module;
+
+export interface InitOutput {
+  readonly memory: WebAssembly.Memory;
+}
+
+/**
+ * Initialize the WASM module. Must be called before any other function.
+ */
+export default function init(
+  module_or_path?:
+    | { module_or_path: InitInput | Promise<InitInput> }
+    | InitInput
+    | Promise<InitInput>,
+): Promise<InitOutput>;

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tiro-health/fhirpath-wasm",
+  "version": "0.1.0",
+  "description": "FHIRPath parser and SDC expression analyzer compiled to WebAssembly",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tiro-health/fhirpath-py.git"
+  },
+  "type": "module",
+  "files": [
+    "_rust_bg.wasm",
+    "_rust.js",
+    "_rust.d.ts",
+    "fhirpath_wasm.d.ts"
+  ],
+  "main": "_rust.js",
+  "types": "fhirpath_wasm.d.ts",
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `wasm` feature flag with `wasm-bindgen` and `serde-wasm-bindgen` dependencies
- Create `src/bindings/wasm.rs` exposing `parse`, `annotate_expression`, `QuestionnaireIndex`, and `analyze_expression`
- Add `Serialize` derives to analysis types and `AstNode` for serde-wasm-bindgen serialization
- Hand-written TypeScript definitions in `wasm/fhirpath_wasm.d.ts`
- npm package config for `@tiro-health/fhirpath-wasm`
- CI workflow step for `wasm-pack build`

Closes #13

## Test plan
- [x] `cargo test --no-default-features` — 54 Rust tests pass
- [x] `cargo check --features wasm --no-default-features` compiles
- [x] `wasm-pack build --target web --features wasm --no-default-features` produces 149KB binary
- [ ] Import in viewer and verify annotation output matches TypeScript types

🤖 Generated with [Claude Code](https://claude.com/claude-code)