### PR TITLE
Fix nested answer.item state transition in annotations

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -259,6 +259,11 @@ fn match_qr_path(steps: &[ChainStep]) -> Option<MatchResult> {
                 QRState::Item
             }
 
+            // Answer + "item" -> Item (nested navigation through answer)
+            (QRState::Answer, ChainStepKind::Identifier(name)) if name == "item" => {
+                QRState::Item
+            }
+
             // Answer + "value" -> Value
             (QRState::Answer, ChainStepKind::Identifier(name)) if name == "value" => {
                 QRState::Value
@@ -571,6 +576,17 @@ mod tests {
         assert_eq!(r.len(), 1);
         assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
             if link_ids == &["a", "b"] && *accessor == ValueAccessor::Code));
+    }
+
+    #[test]
+    fn test_nested_answer_item_navigation() {
+        let r = annotate_expression(
+            "%context.item.where(linkId='verwijzer').answer.item.where(linkId='verwijzend-ziekenhuis').answer.value.display",
+        )
+        .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["verwijzer", "verwijzend-ziekenhuis"] && *accessor == ValueAccessor::Display));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add missing `Answer → Item` transition in the QR navigation state machine
- Fixes nested paths like `answer.item.where(linkId='x').answer.value.display` which were only capturing the first linkId as an item reference instead of the full chain as an answer reference
- Add test for the nested `answer.item` pattern

## Context

Discovered while integrating the WASM module into the sdc-extract-composition viewer. The expression:
```
%context.item.where(linkId='verwijzer').answer.item.where(linkId='verwijzend-ziekenhuis').answer.value.display
```
was rendered as `Verwijzer.answer.item.where(linkId='verwijzend-ziekenhuis').answer.value.display` instead of resolving the full path as a single answer pill.

## Test plan

- [x] New test `test_nested_answer_item_navigation` passes
- [x] All 11 annotation tests pass
- [x] Rebuilt WASM and verified in viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)