### PR TITLE
chore: prepare v3.0.0 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: fhirpathrs
+name: fhirpath-rs
 
 on:
   - push

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish to https://pypi.org/
+name: Publish to PyPI and npm
 
 on:
   release:
@@ -53,7 +53,7 @@ jobs:
           name: dist-${{ matrix.os }}-${{ matrix.target }}
           path: dist
 
-  publish:
+  publish-pypi:
     needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
     permissions:
@@ -66,3 +66,46 @@ jobs:
           path: dist
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        run: wasm-pack build --target web --features wasm --no-default-features
+
+      - name: Overlay custom package metadata and types
+        run: |
+          cp wasm/package.json pkg/package.json
+          cp wasm/fhirpath_wasm.d.ts pkg/fhirpath_wasm.d.ts
+
+      - name: Inject version from Cargo.toml
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "Publishing @tiro-health/fhirpath-wasm v$VERSION"
+          jq --arg v "$VERSION" '.version = $v' pkg/package.json > pkg/package.json.tmp
+          mv pkg/package.json.tmp pkg/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        working-directory: pkg
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --access public --tag next
+          else
+            npm publish --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 3.0.0
+
+### Breaking
+
+- Replace ANTLR4 parser with a Rust FHIRPath parser (PyO3 bindings)
+- Rename Cargo crate from `fhirpathrs` to `fhirpath-rs`
+- Drop ANTLR4 backend and legacy tooling
+- Require Python >= 3.10
+
+### Added
+
+- WASM target: `@tiro-health/fhirpath-wasm` via wasm-bindgen (#13)
+- Analysis API via PyO3: `annotate_expression()`, `analyze_expression()`, `QuestionnaireIndex` (#12)
+- SDC expression analysis with annotation extraction (#7)
+- `QuestionnaireIndex` for questionnaire-aware validation (#8)
+- LinkId validation for SDC expressions (#9)
+- Value type validation for SDC expressions (#10)
+- Context expression validation (#11)
+- Byte offsets on `Token` and `AstNode` (#5)
+- Feature-flagged build: `python` (default) and `wasm` features (#6)
+- `register_as_fhirpathpy()` for drop-in replacement of fhirpathpy
+- Automated PyPI publishing via OIDC trusted publishing
+- Automated npm publishing for WASM package
+
+### Fixed
+
+- Fix missing Answer to Item state transition in annotation state machine
+- Add R5 `coding` item type to value type mapping
+- Use `(system, code)` tuple as answer option key
+
 ## 2.1.0
 
 - Fix bug with $this evaluation context in function invocations #60 @brianpos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "fhirpathrs"
-version = "2.1.0"
+name = "fhirpath-rs"
+version = "3.0.0"
 dependencies = [
  "pyo3",
  "serde",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "memchr"
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "portable-atomic"
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -248,15 +248,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "fhirpathrs"
-version = "2.1.0"
+name = "fhirpath-rs"
+version = "3.0.0"
 edition = "2021"
 
 [lib]

--- a/fhirpathrs/__init__.py
+++ b/fhirpathrs/__init__.py
@@ -9,13 +9,13 @@ from fhirpathrs._rust import (
     QuestionnaireIndex,
 )
 
+from importlib.metadata import version as _get_version
+
 __title__ = "fhirpathrs"
-__version__ = "2.1.0"
+__version__ = _get_version("fhirpathrs")
 __author__ = "beda.software"
 __license__ = "MIT"
-__copyright__ = "Copyright 2025 beda.software"
 
-# Version synonym
 VERSION = __version__
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,10 @@ requires-python = ">=3.10"
 test = ["pytest>=7", "pytest-cov", "pyyaml>=5"]
 
 [project.urls]
-Homepage = "https://github.com/beda-software/fhirpath-py"
-Documentation = "https://github.com/beda-software/fhirpath-py#readme"
-Source = "https://github.com/beda-software/fhirpath-py.git"
-Changelog = "https://github.com/beda-software/fhirpath-py/blob/master/CHANGELOG.md"
+Homepage = "https://github.com/Tiro-health/fhirpath-py"
+Documentation = "https://github.com/Tiro-health/fhirpath-py#readme"
+Source = "https://github.com/Tiro-health/fhirpath-py.git"
+Changelog = "https://github.com/Tiro-health/fhirpath-py/blob/master/CHANGELOG.md"
 
 [tool.ruff]
 target-version = "py310"

--- a/uv.lock
+++ b/uv.lock
@@ -145,7 +145,7 @@ toml = [
 
 [[package]]
 name = "fhirpathrs"
-version = "0.1.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiro-health/fhirpath-wasm",
-  "version": "0.1.0",
+  "version": "0.0.0-placeholder",
   "description": "FHIRPath parser and SDC expression analyzer compiled to WebAssembly",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Rename Cargo crate from fhirpathrs to fhirpath-rs
- Bump version to 3.0.0 (Cargo.toml is single source of truth)
- Dynamic __version__ via importlib.metadata (no more hardcoded version)
- Add publish-wasm job to publish.yaml (npm publish with version injection)
- Handle prereleases with --tag next for npm
- Update project URLs to Tiro-health/fhirpath-py
- Add v3.0.0 changelog