### PR TITLE
feat(analyze): context variables and composite positional ops (#38)

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -10,13 +10,29 @@ use super::{Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode,
 
 // ── Helper types ────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum ContextVarName {
+    This,
+    Index,
+    Total,
+}
+
 pub(crate) enum ChainStepKind {
     Identifier(String),
-    Function { name: String, link_id: Option<String> },
+    Function {
+        name: String,
+        link_id: Option<String>,
+        /// Integer literal argument when the call is `skip(n)` / `take(m)`.
+        /// Used to reason about cardinality in composite positional ops.
+        integer_arg: Option<i64>,
+    },
     External,
+    /// `$this` / `$index` / `$total` — FHIRPath context variables.
+    /// The specific identity is currently only used for debugging; the state
+    /// machine treats all three as transparent pass-throughs at Start.
+    ContextVar(#[allow(dead_code)] ContextVarName),
     /// Bracket indexer `[expr]`. `index` is `Some(n)` only for integer literals.
-    /// Currently only the presence of the indexer matters for attribution;
-    /// the literal value becomes load-bearing in Phase 3.
+    /// Currently only the presence of the indexer matters for attribution.
     Indexer {
         #[allow(dead_code)]
         index: Option<i64>,
@@ -113,7 +129,22 @@ fn find_string_literal_node(node: &AstNode) -> Option<&AstNode> {
 }
 
 /// Navigate TermExpression -> InvocationTerm -> MemberInvocation -> Identifier to get the name.
+///
+/// Also accepts `$this.<ident>` — an InvocationExpression whose receiver is
+/// `$this` and whose member names `<ident>`.
 fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
+    if node.node_type == "InvocationExpression" {
+        let receiver = node.children.first()?;
+        let member = node.children.get(1)?;
+        if !is_this_invocation(receiver) {
+            return None;
+        }
+        if member.node_type != "MemberInvocation" {
+            return None;
+        }
+        return get_identifier_name(member.children.first()?);
+    }
+
     let mut current = node;
     if current.node_type == "TermExpression" {
         current = current.children.first()?;
@@ -127,6 +158,24 @@ fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
     get_identifier_name(current)
 }
 
+/// Returns true if `node` is a `TermExpression -> InvocationTerm -> ThisInvocation`.
+fn is_this_invocation(node: &AstNode) -> bool {
+    let mut current = node;
+    if current.node_type == "TermExpression" {
+        match current.children.first() {
+            Some(c) => current = c,
+            None => return false,
+        }
+    }
+    if current.node_type == "InvocationTerm" {
+        match current.children.first() {
+            Some(c) => current = c,
+            None => return false,
+        }
+    }
+    current.node_type == "ThisInvocation"
+}
+
 /// Recursively flatten an InvocationExpression tree into a chain of steps.
 pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
     match node.node_type {
@@ -135,15 +184,28 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
             match inner.node_type {
                 "InvocationTerm" => {
                     let member = inner.children.first()?;
-                    if member.node_type == "MemberInvocation" {
-                        let ident = member.children.first()?;
-                        let name = get_identifier_name(ident)?.to_string();
-                        Some(vec![ChainStep {
-                            kind: ChainStepKind::Identifier(name),
+                    match member.node_type {
+                        "MemberInvocation" => {
+                            let ident = member.children.first()?;
+                            let name = get_identifier_name(ident)?.to_string();
+                            Some(vec![ChainStep {
+                                kind: ChainStepKind::Identifier(name),
+                                link_id_span: None,
+                            }])
+                        }
+                        "ThisInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::This),
                             link_id_span: None,
-                        }])
-                    } else {
-                        None
+                        }]),
+                        "IndexInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::Index),
+                            link_id_span: None,
+                        }]),
+                        "TotalInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::Total),
+                            link_id_span: None,
+                        }]),
+                        _ => None,
                     }
                 }
                 "ExternalConstantTerm" => {
@@ -191,10 +253,16 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                     } else {
                         (None, None)
                     };
+                    let integer_arg = if func_name == "skip" || func_name == "take" {
+                        extract_first_integer_arg(functn)
+                    } else {
+                        None
+                    };
                     steps.push(ChainStep {
                         kind: ChainStepKind::Function {
                             name: func_name,
                             link_id,
+                            integer_arg,
                         },
                         link_id_span,
                     });
@@ -218,6 +286,16 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
         }
         _ => None,
     }
+}
+
+/// If the `Functn` node has a first argument that is an integer literal, return it.
+fn extract_first_integer_arg(functn: &AstNode) -> Option<i64> {
+    let param_list = functn.children.get(1)?;
+    if param_list.node_type != "ParamList" {
+        return None;
+    }
+    let arg = param_list.children.first()?;
+    extract_integer_literal(arg)
 }
 
 /// Walk TermExpression -> LiteralTerm -> NumberLiteral and parse its text as an integer.
@@ -295,6 +373,37 @@ fn is_positional_function(name: &str) -> bool {
     matches!(name, "first" | "last" | "single" | "tail")
 }
 
+/// `take(1)` — collapses cardinality to one like `first()`.
+fn is_composite_one_positional(step: &ChainStep) -> bool {
+    matches!(
+        &step.kind,
+        ChainStepKind::Function {
+            name,
+            integer_arg: Some(1),
+            ..
+        } if name == "take"
+    )
+}
+
+/// `skip(n)` (any `n`) and `take(m)` with `m != 1` — pass through without
+/// collapsing cardinality. Attribution stays whatever it was.
+fn is_passthrough_skip_or_take(step: &ChainStep) -> bool {
+    match &step.kind {
+        ChainStepKind::Function {
+            name, integer_arg, ..
+        } => {
+            if name == "skip" {
+                true
+            } else if name == "take" {
+                integer_arg != &Some(1)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
 enum MatchKind {
     AnswerRef(ValueAccessor),
     ItemRef,
@@ -319,9 +428,32 @@ enum MatchOutcome {
 
 /// Transition one step.
 fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
+    // Composite positional ops (take(1) / skip / take(m!=1)) applied to an
+    // attributed anchor are handled uniformly: take(1) collapses cardinality,
+    // skip / take(m!=1) just pass through.
+    let attributed = matches!(
+        state.anchor,
+        Anchor::FilteredItems | Anchor::Answer | Anchor::AnswerValue | Anchor::AnswerValueProp(_)
+    );
+    if attributed {
+        if is_composite_one_positional(step) {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            return state;
+        }
+        if is_passthrough_skip_or_take(step) {
+            return state;
+        }
+    }
+
     let next_anchor = match (&state.anchor, &step.kind) {
         // External constants (%context, %resource, %factory...) stay at Start.
         (Anchor::Start, ChainStepKind::External) => Anchor::Start,
+
+        // Context variables ($this / $index / $total) at Start stay at Start —
+        // they're transparent pass-throughs for navigation recognition. Real
+        // attribution in predicates happens via extract_link_id_from_where.
+        (Anchor::Start, ChainStepKind::ContextVar(_)) => Anchor::Start,
 
         // Start + "item" -> Items
         (Anchor::Start, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
@@ -332,6 +464,7 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
             ChainStepKind::Function {
                 name,
                 link_id: Some(id),
+                ..
             },
         ) if name == "where" => {
             state.link_ids.push(id.clone());
@@ -947,5 +1080,95 @@ mod tests {
             diagnostics[0].code,
             DiagnosticCode::ExpressionNotAttributable
         );
+    }
+
+    // ── Phase 3: context variables & composite positional ops ──────────
+
+    #[test]
+    fn test_this_dot_link_id_in_where_is_attributed() {
+        let r =
+            annotate_expression("item.where($this.linkId = 'x').answer.value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        // `$this.linkId` is semantically identical to `linkId` inside a where
+        // predicate, so attribution stays Full.
+        assert_eq!(r[0].attribution, Attribution::Full);
+    }
+
+    #[test]
+    fn test_skip_zero_take_one_demotes_to_partial_positional() {
+        let r =
+            annotate_expression("item.where(linkId='x').answer.skip(0).take(1).value")
+                .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_skip_one_take_two_preserves_attribution() {
+        // take(m) with m != 1 is a pass-through — cardinality stays Many,
+        // attribution stays Full.
+        let r =
+            annotate_expression("item.where(linkId='x').answer.skip(1).take(2).value")
+                .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::Full);
+    }
+
+    #[test]
+    fn test_take_one_between_answer_and_value_demotes() {
+        let r =
+            annotate_expression("item.where(linkId='x').answer.take(1).value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_take_two_is_transparent() {
+        // Standalone .take(m) with m != 1 — no demotion, no diagnostic.
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item.where(linkId='x').answer.take(2).value")
+                .unwrap();
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].attribution, Attribution::Full);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_skip_alone_is_transparent() {
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item.where(linkId='x').answer.skip(1).value")
+                .unwrap();
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].attribution, Attribution::Full);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_dollar_index_in_where_does_not_false_match() {
+        // `$index = 0` inside a where() is not a linkId reference — we must
+        // not mis-attribute it. The chain still degrades because there's no
+        // recognizable linkId predicate, but we shouldn't crash or claim a
+        // linkId that isn't there.
+        let (annotations, _diagnostics) =
+            annotate_expression_with_diagnostics("item.where($index = 0).answer.value")
+                .unwrap();
+        // No annotation with a bogus linkId.
+        for ann in &annotations {
+            match &ann.kind {
+                AnnotationKind::AnswerReference { link_ids, .. }
+                | AnnotationKind::ItemReference { link_ids } => {
+                    assert!(link_ids.is_empty(), "should not invent a linkId");
+                }
+                _ => {}
+            }
+        }
     }
 }

--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -6,7 +6,7 @@
 
 use crate::parser::AstNode;
 
-use super::{Annotation, AnnotationKind, Span, ValueAccessor};
+use super::{Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode, Severity, Span, ValueAccessor};
 
 // ── Helper types ────────────────────────────────────────────────────────
 
@@ -14,6 +14,13 @@ pub(crate) enum ChainStepKind {
     Identifier(String),
     Function { name: String, link_id: Option<String> },
     External,
+    /// Bracket indexer `[expr]`. `index` is `Some(n)` only for integer literals.
+    /// Currently only the presence of the indexer matters for attribution;
+    /// the literal value becomes load-bearing in Phase 3.
+    Indexer {
+        #[allow(dead_code)]
+        index: Option<i64>,
+    },
 }
 
 pub(crate) struct ChainStep {
@@ -197,21 +204,95 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
 
             Some(steps)
         }
+        "IndexerExpression" => {
+            let receiver = node.children.first()?;
+            let index_expr = node.children.get(1)?;
+            let mut steps = decompose_chain(receiver)?;
+            steps.push(ChainStep {
+                kind: ChainStepKind::Indexer {
+                    index: extract_integer_literal(index_expr),
+                },
+                link_id_span: None,
+            });
+            Some(steps)
+        }
         _ => None,
     }
 }
 
-// ── QR state machine ────────────────────────────────────────────────────
+/// Walk TermExpression -> LiteralTerm -> NumberLiteral and parse its text as an integer.
+fn extract_integer_literal(node: &AstNode) -> Option<i64> {
+    let mut current = node;
+    if current.node_type == "TermExpression" {
+        current = current.children.first()?;
+    }
+    if current.node_type == "LiteralTerm" {
+        current = current.children.first()?;
+    }
+    if current.node_type == "NumberLiteral" {
+        let raw = current.terminal_node_text.first()?;
+        return raw.parse::<i64>().ok();
+    }
+    None
+}
 
-#[derive(Debug, Clone)]
-enum QRState {
+// ── QR selection state lattice ──────────────────────────────────────────
+
+/// Where in the QR navigation we currently are.
+#[derive(Debug, Clone, PartialEq)]
+enum Anchor {
+    /// Nothing recognized yet.
     Start,
-    Item,
-    ItemFiltered,
+    /// Arrived at `item` (possibly repeatedly) without a linkId filter.
+    Items,
+    /// Arrived at `item.where(linkId=…)`.
+    FilteredItems,
+    /// Arrived at `…answer`.
     Answer,
-    Value,
-    Prop(ValueAccessor),
-    Rejected,
+    /// Arrived at `…answer.value` (bare Value accessor).
+    AnswerValue,
+    /// Arrived at `…answer.value.<code|display>`.
+    AnswerValueProp(ValueAccessor),
+    /// Left the lattice irrecoverably.
+    Unattributable,
+}
+
+/// Number of elements currently selected.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Cardinality {
+    /// Exactly one (after a positional selector or a known-unique predicate).
+    One,
+    /// Zero or more.
+    Many,
+}
+
+/// Lattice cell propagated through the chain.
+#[derive(Debug, Clone)]
+struct SelectionState {
+    anchor: Anchor,
+    cardinality: Cardinality,
+    attribution: Attribution,
+    link_ids: Vec<String>,
+}
+
+impl SelectionState {
+    fn start() -> Self {
+        Self {
+            anchor: Anchor::Start,
+            cardinality: Cardinality::Many,
+            attribution: Attribution::Full,
+            link_ids: Vec::new(),
+        }
+    }
+
+    fn in_qr_scope(&self) -> bool {
+        !matches!(self.anchor, Anchor::Start | Anchor::Unattributable)
+    }
+}
+
+/// Set of positional selector function names that narrow cardinality to one.
+fn is_positional_function(name: &str) -> bool {
+    matches!(name, "first" | "last" | "single" | "tail")
 }
 
 enum MatchKind {
@@ -222,119 +303,245 @@ enum MatchKind {
 struct MatchResult {
     link_ids: Vec<String>,
     kind: MatchKind,
+    attribution: Attribution,
 }
 
-/// Run the QR navigation state machine over a chain of steps.
-fn match_qr_path(steps: &[ChainStep]) -> Option<MatchResult> {
-    let mut state = QRState::Start;
-    let mut link_ids: Vec<String> = Vec::new();
+/// Outcome of running the state machine over a chain.
+enum MatchOutcome {
+    /// Chain produced a recognizable QR reference.
+    Annotation(MatchResult),
+    /// Chain entered a QR-meaningful state then lost attribution —
+    /// caller should emit an `ExpressionNotAttributable` diagnostic.
+    Unattributable,
+    /// Chain never entered a QR-meaningful state (e.g. `Patient.name.given`).
+    NotApplicable,
+}
+
+/// Transition one step.
+fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
+    let next_anchor = match (&state.anchor, &step.kind) {
+        // External constants (%context, %resource, %factory...) stay at Start.
+        (Anchor::Start, ChainStepKind::External) => Anchor::Start,
+
+        // Start + "item" -> Items
+        (Anchor::Start, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
+
+        // Items + where(linkId=…) -> FilteredItems
+        (
+            Anchor::Items,
+            ChainStepKind::Function {
+                name,
+                link_id: Some(id),
+            },
+        ) if name == "where" => {
+            state.link_ids.push(id.clone());
+            Anchor::FilteredItems
+        }
+
+        // FilteredItems / Answer -> descend through .item (nested navigation)
+        (Anchor::FilteredItems, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
+        (Anchor::Answer, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
+
+        // FilteredItems + answer -> Answer
+        (Anchor::FilteredItems, ChainStepKind::Identifier(name)) if name == "answer" => {
+            Anchor::Answer
+        }
+
+        // Answer + value -> AnswerValue
+        (Anchor::Answer, ChainStepKind::Identifier(name)) if name == "value" => Anchor::AnswerValue,
+
+        // AnswerValue + code/display -> AnswerValueProp
+        (Anchor::AnswerValue, ChainStepKind::Identifier(name)) if name == "code" => {
+            Anchor::AnswerValueProp(ValueAccessor::Code)
+        }
+        (Anchor::AnswerValue, ChainStepKind::Identifier(name)) if name == "display" => {
+            Anchor::AnswerValueProp(ValueAccessor::Display)
+        }
+
+        // Positional selectors (first/last/single/tail/indexer).
+        //
+        // On attributed anchors (FilteredItems / Answer / AnswerValue /
+        // AnswerValueProp) they keep the anchor, narrow cardinality to One,
+        // and demote attribution to PartialPositional.
+        //
+        // On Items (unfiltered) they strip attribution — we can no longer
+        // say which linkId we're targeting.
+        (Anchor::FilteredItems, ChainStepKind::Function { name, .. })
+            if is_positional_function(name) =>
+        {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::FilteredItems
+        }
+        (Anchor::Answer, ChainStepKind::Function { name, .. })
+            if is_positional_function(name) =>
+        {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::Answer
+        }
+        (Anchor::AnswerValue, ChainStepKind::Function { name, .. })
+            if is_positional_function(name) =>
+        {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::AnswerValue
+        }
+        (Anchor::AnswerValueProp(prop), ChainStepKind::Function { name, .. })
+            if is_positional_function(name) =>
+        {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::AnswerValueProp(prop.clone())
+        }
+        (Anchor::FilteredItems, ChainStepKind::Indexer { .. }) => {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::FilteredItems
+        }
+        (Anchor::Answer, ChainStepKind::Indexer { .. }) => {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::Answer
+        }
+        (Anchor::AnswerValue, ChainStepKind::Indexer { .. }) => {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::AnswerValue
+        }
+        (Anchor::AnswerValueProp(prop), ChainStepKind::Indexer { .. }) => {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            Anchor::AnswerValueProp(prop.clone())
+        }
+        // Positional on unfiltered Items: can't attribute.
+        (Anchor::Items, ChainStepKind::Function { name, .. })
+            if is_positional_function(name) =>
+        {
+            Anchor::Unattributable
+        }
+        (Anchor::Items, ChainStepKind::Indexer { .. }) => Anchor::Unattributable,
+
+        // Any step on Unattributable keeps us Unattributable.
+        (Anchor::Unattributable, _) => Anchor::Unattributable,
+
+        // Anything else walks off the lattice. If we were inside a QR scope,
+        // signal Unattributable so the caller emits a diagnostic; if we were
+        // still at Start, the chain simply doesn't apply to us.
+        _ => {
+            if state.in_qr_scope() {
+                Anchor::Unattributable
+            } else {
+                // Stay at Start: non-QR chain (e.g. Patient.name).
+                return SelectionState {
+                    anchor: Anchor::Start,
+                    cardinality: Cardinality::Many,
+                    attribution: Attribution::Full,
+                    link_ids: Vec::new(),
+                };
+            }
+        }
+    };
+
+    state.anchor = next_anchor;
+    state
+}
+
+/// Run the state machine and classify the terminal state.
+fn match_qr_path(steps: &[ChainStep]) -> MatchOutcome {
+    let mut state = SelectionState::start();
+    let mut ever_in_qr_scope = false;
 
     for step in steps {
-        state = match (&state, &step.kind) {
-            // Start + External -> Start (skip %context, %resource, etc.)
-            (QRState::Start, ChainStepKind::External) => QRState::Start,
-
-            // Start + "item" -> Item
-            (QRState::Start, ChainStepKind::Identifier(name)) if name == "item" => QRState::Item,
-
-            // Item + where(linkId=...) -> ItemFiltered
-            (
-                QRState::Item,
-                ChainStepKind::Function {
-                    name,
-                    link_id: Some(id),
-                },
-            ) if name == "where" => {
-                link_ids.push(id.clone());
-                QRState::ItemFiltered
-            }
-
-            // ItemFiltered + "answer" -> Answer
-            (QRState::ItemFiltered, ChainStepKind::Identifier(name)) if name == "answer" => {
-                QRState::Answer
-            }
-
-            // ItemFiltered + "item" -> Item (nested navigation)
-            (QRState::ItemFiltered, ChainStepKind::Identifier(name)) if name == "item" => {
-                QRState::Item
-            }
-
-            // Answer + "item" -> Item (nested navigation through answer)
-            (QRState::Answer, ChainStepKind::Identifier(name)) if name == "item" => {
-                QRState::Item
-            }
-
-            // Answer + "value" -> Value
-            (QRState::Answer, ChainStepKind::Identifier(name)) if name == "value" => {
-                QRState::Value
-            }
-
-            // Value + "code" -> Prop(Code)
-            (QRState::Value, ChainStepKind::Identifier(name)) if name == "code" => {
-                QRState::Prop(ValueAccessor::Code)
-            }
-
-            // Value + "display" -> Prop(Display)
-            (QRState::Value, ChainStepKind::Identifier(name)) if name == "display" => {
-                QRState::Prop(ValueAccessor::Display)
-            }
-
-            // Everything else -> Rejected
-            _ => QRState::Rejected,
-        };
-
-        if matches!(state, QRState::Rejected) {
-            return None;
+        state = transition(state, step);
+        if state.in_qr_scope() {
+            ever_in_qr_scope = true;
+        }
+        if matches!(state.anchor, Anchor::Unattributable) {
+            return MatchOutcome::Unattributable;
         }
     }
 
-    match state {
-        QRState::Value => Some(MatchResult {
-            link_ids,
+    match state.anchor {
+        Anchor::AnswerValue => MatchOutcome::Annotation(MatchResult {
+            link_ids: state.link_ids,
             kind: MatchKind::AnswerRef(ValueAccessor::Value),
+            attribution: state.attribution,
         }),
-        QRState::Prop(accessor) => Some(MatchResult {
-            link_ids,
+        Anchor::AnswerValueProp(accessor) => MatchOutcome::Annotation(MatchResult {
+            link_ids: state.link_ids,
             kind: MatchKind::AnswerRef(accessor),
+            attribution: state.attribution,
         }),
-        QRState::ItemFiltered if !link_ids.is_empty() => Some(MatchResult {
-            link_ids,
-            kind: MatchKind::ItemRef,
-        }),
-        _ => None,
+        Anchor::FilteredItems if !state.link_ids.is_empty() => {
+            MatchOutcome::Annotation(MatchResult {
+                link_ids: state.link_ids,
+                kind: MatchKind::ItemRef,
+                attribution: state.attribution,
+            })
+        }
+        // Reached `item` / `item.answer` but no usable terminal — treat as
+        // unattributable only if we actually walked into QR territory.
+        _ if ever_in_qr_scope => MatchOutcome::Unattributable,
+        _ => MatchOutcome::NotApplicable,
     }
 }
 
 // ── AST walkers ─────────────────────────────────────────────────────────
 
 /// Pass 1: Find answer and item references by DFS over the AST.
-fn find_answer_refs(node: &AstNode, out: &mut Vec<Annotation>) {
+/// Also emits `ExpressionNotAttributable` diagnostics for chains that entered
+/// QR territory but degraded.
+fn find_answer_refs(node: &AstNode, out: &mut Vec<Annotation>, diagnostics: &mut Vec<Diagnostic>) {
     // Try to match this node as a QR navigation chain
-    if node.node_type == "InvocationExpression" || node.node_type == "TermExpression" {
+    if matches!(
+        node.node_type,
+        "InvocationExpression" | "TermExpression" | "IndexerExpression"
+    ) {
         if let Some(steps) = decompose_chain(node) {
-            if let Some(result) = match_qr_path(&steps) {
-                let span = Span {
-                    start: node.byte_start,
-                    end: node.byte_end,
-                };
-                let kind = match result.kind {
-                    MatchKind::AnswerRef(accessor) => AnnotationKind::AnswerReference {
-                        link_ids: result.link_ids,
-                        accessor,
-                    },
-                    MatchKind::ItemRef => AnnotationKind::ItemReference {
-                        link_ids: result.link_ids,
-                    },
-                };
-                out.push(Annotation { span, kind });
-                return; // Don't recurse into children of a matched node
+            let span = Span {
+                start: node.byte_start,
+                end: node.byte_end,
+            };
+            match match_qr_path(&steps) {
+                MatchOutcome::Annotation(result) => {
+                    let kind = match result.kind {
+                        MatchKind::AnswerRef(accessor) => AnnotationKind::AnswerReference {
+                            link_ids: result.link_ids,
+                            accessor,
+                        },
+                        MatchKind::ItemRef => AnnotationKind::ItemReference {
+                            link_ids: result.link_ids,
+                        },
+                    };
+                    out.push(Annotation {
+                        span,
+                        kind,
+                        attribution: result.attribution,
+                    });
+                    return; // Don't recurse into children of a matched node
+                }
+                MatchOutcome::Unattributable => {
+                    diagnostics.push(Diagnostic {
+                        span,
+                        severity: Severity::Info,
+                        code: DiagnosticCode::ExpressionNotAttributable,
+                        message:
+                            "Expression navigates into a QuestionnaireResponse but cannot be attributed to a specific linkId"
+                                .to_string(),
+                    });
+                    return;
+                }
+                MatchOutcome::NotApplicable => {
+                    // Fall through to recurse.
+                }
             }
         }
     }
 
     // Recurse into children
     for child in &node.children {
-        find_answer_refs(child, out);
+        find_answer_refs(child, out, diagnostics);
     }
 }
 
@@ -493,6 +700,7 @@ fn find_coded_values(node: &AstNode, answer_refs: &[Annotation], out: &mut Vec<A
                     system,
                     context_link_id,
                 },
+                attribution: Attribution::Full,
             });
             return;
         }
@@ -505,6 +713,7 @@ fn find_coded_values(node: &AstNode, answer_refs: &[Annotation], out: &mut Vec<A
                     system: None,
                     context_link_id,
                 },
+                attribution: Attribution::Full,
             });
             return;
         }
@@ -521,19 +730,28 @@ fn find_coded_values(node: &AstNode, answer_refs: &[Annotation], out: &mut Vec<A
 /// Annotate a FHIRPath expression string, extracting answer references,
 /// item references, and coded values.
 pub fn annotate_expression(expr: &str) -> Result<Vec<Annotation>, crate::ParseError> {
+    Ok(annotate_expression_with_diagnostics(expr)?.0)
+}
+
+/// Variant of [`annotate_expression`] that also returns diagnostics emitted
+/// during annotation (currently just `ExpressionNotAttributable`).
+pub(crate) fn annotate_expression_with_diagnostics(
+    expr: &str,
+) -> Result<(Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
     let tokens = crate::lexer::tokenize(expr).map_err(crate::ParseError)?;
     let mut p = crate::parser::Parser::new(&tokens);
     let root = p.parse_entire_expression().map_err(crate::ParseError)?;
 
     let mut answer_refs = Vec::new();
-    find_answer_refs(&root, &mut answer_refs);
+    let mut diagnostics = Vec::new();
+    find_answer_refs(&root, &mut answer_refs, &mut diagnostics);
 
     let mut coded_values = Vec::new();
     find_coded_values(&root, &answer_refs, &mut coded_values);
 
     let mut all: Vec<Annotation> = answer_refs.into_iter().chain(coded_values).collect();
     all.sort_by_key(|a| a.span.start);
-    Ok(all)
+    Ok((all, diagnostics))
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -640,5 +858,94 @@ mod tests {
         let r = annotate_expression(expr).unwrap();
         assert_eq!(r[0].span.start, 0);
         assert_eq!(r[0].span.end, expr.len());
+    }
+
+    // ── Phase 1: positional selectors & attribution ─────────────────────
+
+    #[test]
+    fn test_first_between_where_and_answer_demotes_attribution() {
+        // item.where(linkId='x').first().answer.value
+        let r =
+            annotate_expression("item.where(linkId='x').first().answer.value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_first_after_value_demotes_attribution() {
+        let r = annotate_expression("item.where(linkId='x').answer.value.first()").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_indexer_on_unfiltered_item_is_unattributable() {
+        // item[0].answer.value — no linkId filter, positional op -> diagnostic
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item[0].answer.value").unwrap();
+        assert!(annotations.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::ExpressionNotAttributable
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn test_indexer_after_where_demotes_item_ref() {
+        let r = annotate_expression("item.where(linkId='x')[0]").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::ItemReference { link_ids }
+            if link_ids == &["x"]));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_full_attribution_preserved_for_legacy_chain() {
+        // Regression guard: pre-existing patterns stay `Full`.
+        let r = annotate_expression("item.where(linkId='x').answer.value.code").unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].attribution, Attribution::Full);
+    }
+
+    #[test]
+    fn test_non_qr_expression_no_diagnostic() {
+        // Plain FHIR navigation produces neither annotation nor diagnostic.
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("Patient.name.given").unwrap();
+        assert!(annotations.is_empty());
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_single_positional_demotes() {
+        let r =
+            annotate_expression("item.where(linkId='x').answer.value.single()").unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_last_positional_demotes() {
+        let r = annotate_expression("item.where(linkId='x').last().answer.value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_first_on_unfiltered_items_is_unattributable() {
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item.first().answer.value").unwrap();
+        assert!(annotations.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::ExpressionNotAttributable
+        );
     }
 }

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -41,10 +41,34 @@ pub enum AnnotationKind {
     },
 }
 
+/// How precisely an annotation attributes to its linkId scope.
+///
+/// `Full` — the expression navigates to the complete set of answers/items
+/// for the named linkId(s).
+///
+/// `PartialPositional` — a positional selector (`first()`, `[i]`, etc.)
+/// narrowed the navigation to a subset. The linkId attribution still holds,
+/// but the evaluator sees fewer items than a bare `where(linkId=…)` would.
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Attribution {
+    #[default]
+    Full,
+    PartialPositional,
+}
+
+impl Attribution {
+    pub(crate) fn is_default(&self) -> bool {
+        matches!(self, Attribution::Full)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Annotation {
     pub span: Span,
     pub kind: AnnotationKind,
+    #[serde(default, skip_serializing_if = "Attribution::is_default")]
+    pub attribution: Attribution,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -52,6 +76,7 @@ pub struct Annotation {
 pub enum Severity {
     Error,
     Warning,
+    Info,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -63,6 +88,7 @@ pub enum DiagnosticCode {
     MissingAccessorForCoding,
     ItemReferenceTargetsLeaf,
     ContextUnreachableFromParent,
+    ExpressionNotAttributable,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -110,8 +136,7 @@ pub fn analyze_expression(
     index: &questionnaire_index::QuestionnaireIndex,
     context: &AnalysisContext,
 ) -> Result<ExpressionAnalysis, crate::ParseError> {
-    let ann = annotations::annotate_expression(expr)?;
-    let mut diagnostics = Vec::new();
+    let (ann, mut diagnostics) = annotations::annotate_expression_with_diagnostics(expr)?;
 
     // 1. LinkId validation — applies to ALL expressions
     diagnostics.extend(validate_link_ids::validate_link_ids_from_expr(

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -22,6 +22,7 @@ fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
                 if let ChainStepKind::Function {
                     name,
                     link_id: Some(id),
+                    ..
                 } = &step.kind
                 {
                     if name == "where" {

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -13,7 +13,10 @@ fn collect_link_id_references(node: &AstNode) -> Vec<(String, Span)> {
 
 fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
     // Try to decompose this node as a chain and extract linkIds from where() steps
-    if node.node_type == "InvocationExpression" || node.node_type == "TermExpression" {
+    if matches!(
+        node.node_type,
+        "InvocationExpression" | "TermExpression" | "IndexerExpression"
+    ) {
         if let Some(steps) = decompose_chain(node) {
             for step in &steps {
                 if let ChainStepKind::Function {

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use crate::analyze::{
-    self, AnnotationKind, DiagnosticCode, Severity, ValueAccessor,
+    self, AnnotationKind, Attribution, DiagnosticCode, Severity, ValueAccessor,
 };
 use crate::lexer::Token;
 use crate::AstNode;
@@ -127,6 +127,7 @@ fn severity_to_str(severity: &Severity) -> &'static str {
     match severity {
         Severity::Error => "error",
         Severity::Warning => "warning",
+        Severity::Info => "info",
     }
 }
 
@@ -138,6 +139,7 @@ fn diagnostic_code_to_str(code: &DiagnosticCode) -> &'static str {
         DiagnosticCode::MissingAccessorForCoding => "missing_accessor_for_coding",
         DiagnosticCode::ItemReferenceTargetsLeaf => "item_reference_targets_leaf",
         DiagnosticCode::ContextUnreachableFromParent => "context_unreachable_from_parent",
+        DiagnosticCode::ExpressionNotAttributable => "expression_not_attributable",
     }
 }
 
@@ -171,7 +173,19 @@ fn annotation_to_pydict(py: Python<'_>, ann: &analyze::Annotation) -> PyResult<P
             dict.set_item("context_link_id", context_link_id.as_str())?;
         }
     }
+    // Only emit `attribution` when non-default, preserving v3.0.0 dict shapes
+    // for callers that don't care about positional selectors.
+    if !ann.attribution.is_default() {
+        dict.set_item("attribution", attribution_to_str(&ann.attribution))?;
+    }
     Ok(dict.into())
+}
+
+fn attribution_to_str(attribution: &Attribution) -> &'static str {
+    match attribution {
+        Attribution::Full => "full",
+        Attribution::PartialPositional => "partial_positional",
+    }
 }
 
 fn diagnostic_to_pydict(py: Python<'_>, diag: &analyze::Diagnostic) -> PyResult<PyObject> {

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -167,6 +167,40 @@ def annotate_syntax_error_test():
         annotate_expression("!")
 
 
+# ── annotate_expression: positional selectors (Phase 1) ────────────────
+
+
+def annotate_positional_after_where_demotes_attribution_test():
+    result = annotate_expression("item.where(linkId='x').first().answer.value")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "answer_reference"
+    assert ann["link_ids"] == ["x"]
+    assert ann["accessor"] == "value"
+    assert ann["attribution"] == "partial_positional"
+
+
+def annotate_positional_after_value_demotes_attribution_test():
+    result = annotate_expression("item.where(linkId='x').answer.value.first()")
+    assert len(result) == 1
+    assert result[0]["attribution"] == "partial_positional"
+
+
+def annotate_indexer_after_where_demotes_item_ref_test():
+    result = annotate_expression("item.where(linkId='x')[0]")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "item_reference"
+    assert ann["link_ids"] == ["x"]
+    assert ann["attribution"] == "partial_positional"
+
+
+def annotate_full_attribution_not_emitted_for_clean_chain_test():
+    # Wire compat: dict shape is byte-identical to v3.0.0 when attribution is Full.
+    result = annotate_expression("item.where(linkId='x').answer.value.code")
+    assert "attribution" not in result[0]
+
+
 # ── analyze_expression ─────────────────────────────────────────────────
 
 
@@ -253,3 +287,14 @@ def analyze_syntax_error_test():
     idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
     with pytest.raises(SyntaxError):
         analyze_expression("!", idx)
+
+
+def analyze_expression_not_attributable_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("item[0].answer.value", idx)
+    diags = result["diagnostics"]
+    assert any(d["code"] == "expression_not_attributable" for d in diags)
+    diag = next(d for d in diags if d["code"] == "expression_not_attributable")
+    assert diag["severity"] == "info"
+    # No annotation because the chain is unattributable.
+    assert result["annotations"] == []

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -201,6 +201,51 @@ def annotate_full_attribution_not_emitted_for_clean_chain_test():
     assert "attribution" not in result[0]
 
 
+# ── annotate_expression: context variables & composite positional (Phase 3)
+
+
+def annotate_this_dot_link_id_in_where_test():
+    # `$this.linkId = 'x'` inside where() is equivalent to `linkId = 'x'`.
+    result = annotate_expression("item.where($this.linkId = 'x').answer.value")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "answer_reference"
+    assert ann["link_ids"] == ["x"]
+    # Full attribution preserved — wire shape omits the attribution key.
+    assert "attribution" not in ann
+
+
+def annotate_skip_zero_take_one_demotes_test():
+    result = annotate_expression("item.where(linkId='x').answer.skip(0).take(1).value")
+    assert len(result) == 1
+    assert result[0]["attribution"] == "partial_positional"
+
+
+def annotate_skip_one_take_two_preserves_attribution_test():
+    # `.skip(1).take(2)` leaves cardinality at Many → attribution stays Full.
+    result = annotate_expression("item.where(linkId='x').answer.skip(1).take(2).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
+def annotate_take_one_demotes_test():
+    result = annotate_expression("item.where(linkId='x').answer.take(1).value")
+    assert len(result) == 1
+    assert result[0]["attribution"] == "partial_positional"
+
+
+def annotate_take_many_is_transparent_test():
+    result = annotate_expression("item.where(linkId='x').answer.take(5).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
+def annotate_skip_alone_is_transparent_test():
+    result = annotate_expression("item.where(linkId='x').answer.skip(3).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
 # ── analyze_expression ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #38.

## Summary

Extends the selection-state lattice from #36 to understand FHIRPath context variables (`$this`/`$index`/`$total`) and the `.skip(n)`/`.take(m)` composite positional ops. Expressions that were previously dropped as `ExpressionNotAttributable` now resolve cleanly.

- **`$this.linkId = '…'` inside `where()`** is recognized as a linkId reference — `item.where(\$this.linkId = 'x').answer.value` now annotates with `link_ids: ['x']` instead of degrading.
- **`.take(1)`** (alone or following `.skip(n)`) collapses cardinality to One and demotes attribution `Full → PartialPositional`, consistent with `first()`.
- **`.skip(n)`** (any `n`) and **`.take(m)` with `m != 1`** are transparent pass-throughs — cardinality stays `Many`, attribution unchanged.
- **`\$index`/`\$total`** in predicates no longer trigger false linkId matches.

## Wire compatibility

No new serialized enum variants. `partial_positional` (from #36) is the only attribution string that can appear. `Full` still omits the `attribution` key entirely, preserving v3.0.0 dict shape for clean chains.

## Depends on

- #36 (Phase 1) — merged in via PR #40 in the base branch
- Phase 2 (#37) was deferred; this PR implements Phase 3 directly on top of Phase 1 per the \"ideally, not strictly required\" note in #38

## Test plan

- [x] `cargo test --lib` — 71 pass (7 new Phase 3 cases added)
- [x] `uv run pytest tests/test_analyze.py` — 33 pass (6 new Phase 3 cases)
- [x] `uv run pytest` full suite — 1751 pass
- [x] `cargo check` for default, `--features python`, and `--no-default-features --features wasm --target wasm32-unknown-unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)