### PR TITLE
feat(analyze): widened scope and unattributable attributions (#37)

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -10,13 +10,29 @@ use super::{Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode,
 
 // ── Helper types ────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum ContextVarName {
+    This,
+    Index,
+    Total,
+}
+
 pub(crate) enum ChainStepKind {
     Identifier(String),
-    Function { name: String, link_id: Option<String> },
+    Function {
+        name: String,
+        link_id: Option<String>,
+        /// Integer literal argument when the call is `skip(n)` / `take(m)`.
+        /// Used to reason about cardinality in composite positional ops.
+        integer_arg: Option<i64>,
+    },
     External,
+    /// `$this` / `$index` / `$total` — FHIRPath context variables.
+    /// The specific identity is currently only used for debugging; the state
+    /// machine treats all three as transparent pass-throughs at Start.
+    ContextVar(#[allow(dead_code)] ContextVarName),
     /// Bracket indexer `[expr]`. `index` is `Some(n)` only for integer literals.
-    /// Currently only the presence of the indexer matters for attribution;
-    /// the literal value becomes load-bearing in Phase 3.
+    /// Currently only the presence of the indexer matters for attribution.
     Indexer {
         #[allow(dead_code)]
         index: Option<i64>,
@@ -113,7 +129,22 @@ fn find_string_literal_node(node: &AstNode) -> Option<&AstNode> {
 }
 
 /// Navigate TermExpression -> InvocationTerm -> MemberInvocation -> Identifier to get the name.
+///
+/// Also accepts `$this.<ident>` — an InvocationExpression whose receiver is
+/// `$this` and whose member names `<ident>`.
 fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
+    if node.node_type == "InvocationExpression" {
+        let receiver = node.children.first()?;
+        let member = node.children.get(1)?;
+        if !is_this_invocation(receiver) {
+            return None;
+        }
+        if member.node_type != "MemberInvocation" {
+            return None;
+        }
+        return get_identifier_name(member.children.first()?);
+    }
+
     let mut current = node;
     if current.node_type == "TermExpression" {
         current = current.children.first()?;
@@ -127,6 +158,24 @@ fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
     get_identifier_name(current)
 }
 
+/// Returns true if `node` is a `TermExpression -> InvocationTerm -> ThisInvocation`.
+fn is_this_invocation(node: &AstNode) -> bool {
+    let mut current = node;
+    if current.node_type == "TermExpression" {
+        match current.children.first() {
+            Some(c) => current = c,
+            None => return false,
+        }
+    }
+    if current.node_type == "InvocationTerm" {
+        match current.children.first() {
+            Some(c) => current = c,
+            None => return false,
+        }
+    }
+    current.node_type == "ThisInvocation"
+}
+
 /// Recursively flatten an InvocationExpression tree into a chain of steps.
 pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
     match node.node_type {
@@ -135,15 +184,28 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
             match inner.node_type {
                 "InvocationTerm" => {
                     let member = inner.children.first()?;
-                    if member.node_type == "MemberInvocation" {
-                        let ident = member.children.first()?;
-                        let name = get_identifier_name(ident)?.to_string();
-                        Some(vec![ChainStep {
-                            kind: ChainStepKind::Identifier(name),
+                    match member.node_type {
+                        "MemberInvocation" => {
+                            let ident = member.children.first()?;
+                            let name = get_identifier_name(ident)?.to_string();
+                            Some(vec![ChainStep {
+                                kind: ChainStepKind::Identifier(name),
+                                link_id_span: None,
+                            }])
+                        }
+                        "ThisInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::This),
                             link_id_span: None,
-                        }])
-                    } else {
-                        None
+                        }]),
+                        "IndexInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::Index),
+                            link_id_span: None,
+                        }]),
+                        "TotalInvocation" => Some(vec![ChainStep {
+                            kind: ChainStepKind::ContextVar(ContextVarName::Total),
+                            link_id_span: None,
+                        }]),
+                        _ => None,
                     }
                 }
                 "ExternalConstantTerm" => {
@@ -191,10 +253,16 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                     } else {
                         (None, None)
                     };
+                    let integer_arg = if func_name == "skip" || func_name == "take" {
+                        extract_first_integer_arg(functn)
+                    } else {
+                        None
+                    };
                     steps.push(ChainStep {
                         kind: ChainStepKind::Function {
                             name: func_name,
                             link_id,
+                            integer_arg,
                         },
                         link_id_span,
                     });
@@ -218,6 +286,16 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
         }
         _ => None,
     }
+}
+
+/// If the `Functn` node has a first argument that is an integer literal, return it.
+fn extract_first_integer_arg(functn: &AstNode) -> Option<i64> {
+    let param_list = functn.children.get(1)?;
+    if param_list.node_type != "ParamList" {
+        return None;
+    }
+    let arg = param_list.children.first()?;
+    extract_integer_literal(arg)
 }
 
 /// Walk TermExpression -> LiteralTerm -> NumberLiteral and parse its text as an integer.
@@ -295,6 +373,37 @@ fn is_positional_function(name: &str) -> bool {
     matches!(name, "first" | "last" | "single" | "tail")
 }
 
+/// `take(1)` — collapses cardinality to one like `first()`.
+fn is_composite_one_positional(step: &ChainStep) -> bool {
+    matches!(
+        &step.kind,
+        ChainStepKind::Function {
+            name,
+            integer_arg: Some(1),
+            ..
+        } if name == "take"
+    )
+}
+
+/// `skip(n)` (any `n`) and `take(m)` with `m != 1` — pass through without
+/// collapsing cardinality. Attribution stays whatever it was.
+fn is_passthrough_skip_or_take(step: &ChainStep) -> bool {
+    match &step.kind {
+        ChainStepKind::Function {
+            name, integer_arg, ..
+        } => {
+            if name == "skip" {
+                true
+            } else if name == "take" {
+                integer_arg != &Some(1)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
 enum MatchKind {
     AnswerRef(ValueAccessor),
     ItemRef,
@@ -319,9 +428,32 @@ enum MatchOutcome {
 
 /// Transition one step.
 fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
+    // Composite positional ops (take(1) / skip / take(m!=1)) applied to an
+    // attributed anchor are handled uniformly: take(1) collapses cardinality,
+    // skip / take(m!=1) just pass through.
+    let attributed = matches!(
+        state.anchor,
+        Anchor::FilteredItems | Anchor::Answer | Anchor::AnswerValue | Anchor::AnswerValueProp(_)
+    );
+    if attributed {
+        if is_composite_one_positional(step) {
+            state.attribution = Attribution::PartialPositional;
+            state.cardinality = Cardinality::One;
+            return state;
+        }
+        if is_passthrough_skip_or_take(step) {
+            return state;
+        }
+    }
+
     let next_anchor = match (&state.anchor, &step.kind) {
         // External constants (%context, %resource, %factory...) stay at Start.
         (Anchor::Start, ChainStepKind::External) => Anchor::Start,
+
+        // Context variables ($this / $index / $total) at Start stay at Start —
+        // they're transparent pass-throughs for navigation recognition. Real
+        // attribution in predicates happens via extract_link_id_from_where.
+        (Anchor::Start, ChainStepKind::ContextVar(_)) => Anchor::Start,
 
         // Start + "item" -> Items
         (Anchor::Start, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
@@ -332,6 +464,7 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
             ChainStepKind::Function {
                 name,
                 link_id: Some(id),
+                ..
             },
         ) if name == "where" => {
             state.link_ids.push(id.clone());
@@ -947,5 +1080,95 @@ mod tests {
             diagnostics[0].code,
             DiagnosticCode::ExpressionNotAttributable
         );
+    }
+
+    // ── Phase 3: context variables & composite positional ops ──────────
+
+    #[test]
+    fn test_this_dot_link_id_in_where_is_attributed() {
+        let r =
+            annotate_expression("item.where($this.linkId = 'x').answer.value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        // `$this.linkId` is semantically identical to `linkId` inside a where
+        // predicate, so attribution stays Full.
+        assert_eq!(r[0].attribution, Attribution::Full);
+    }
+
+    #[test]
+    fn test_skip_zero_take_one_demotes_to_partial_positional() {
+        let r =
+            annotate_expression("item.where(linkId='x').answer.skip(0).take(1).value")
+                .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_skip_one_take_two_preserves_attribution() {
+        // take(m) with m != 1 is a pass-through — cardinality stays Many,
+        // attribution stays Full.
+        let r =
+            annotate_expression("item.where(linkId='x').answer.skip(1).take(2).value")
+                .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::Full);
+    }
+
+    #[test]
+    fn test_take_one_between_answer_and_value_demotes() {
+        let r =
+            annotate_expression("item.where(linkId='x').answer.take(1).value").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::PartialPositional);
+    }
+
+    #[test]
+    fn test_take_two_is_transparent() {
+        // Standalone .take(m) with m != 1 — no demotion, no diagnostic.
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item.where(linkId='x').answer.take(2).value")
+                .unwrap();
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].attribution, Attribution::Full);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_skip_alone_is_transparent() {
+        let (annotations, diagnostics) =
+            annotate_expression_with_diagnostics("item.where(linkId='x').answer.skip(1).value")
+                .unwrap();
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].attribution, Attribution::Full);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_dollar_index_in_where_does_not_false_match() {
+        // `$index = 0` inside a where() is not a linkId reference — we must
+        // not mis-attribute it. The chain still degrades because there's no
+        // recognizable linkId predicate, but we shouldn't crash or claim a
+        // linkId that isn't there.
+        let (annotations, _diagnostics) =
+            annotate_expression_with_diagnostics("item.where($index = 0).answer.value")
+                .unwrap();
+        // No annotation with a bogus linkId.
+        for ann in &annotations {
+            match &ann.kind {
+                AnnotationKind::AnswerReference { link_ids, .. }
+                | AnnotationKind::ItemReference { link_ids } => {
+                    assert!(link_ids.is_empty(), "should not invent a linkId");
+                }
+                _ => {}
+            }
+        }
     }
 }

--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -331,7 +331,12 @@ enum Anchor {
     AnswerValue,
     /// Arrived at `…answer.value.<code|display>`.
     AnswerValueProp(ValueAccessor),
-    /// Left the lattice irrecoverably.
+    /// After a scope-widening operation (`descendants()`, `children()`,
+    /// `repeat()`). We're inside QR territory but no longer tracking a
+    /// structural parent-chain.
+    Widened,
+    /// Left the lattice irrecoverably — `first()` on unfiltered `item`,
+    /// unknown identifier on a navigation chain, etc.
     Unattributable,
 }
 
@@ -366,6 +371,34 @@ impl SelectionState {
     fn in_qr_scope(&self) -> bool {
         !matches!(self.anchor, Anchor::Start | Anchor::Unattributable)
     }
+
+    /// Anchors on which attribution-demoting ops should keep the anchor but
+    /// lower attribution, rather than hard-stopping to `Unattributable`.
+    fn is_attributed_anchor(&self) -> bool {
+        matches!(
+            self.anchor,
+            Anchor::FilteredItems
+                | Anchor::Answer
+                | Anchor::AnswerValue
+                | Anchor::AnswerValueProp(_)
+                | Anchor::Widened
+                | Anchor::Items
+        )
+    }
+}
+
+/// Degrade attribution for a scope-widening step (`descendants`, `children`,
+/// `repeat`). `Full` → `WidenedScope`; anything already lossy drops to
+/// `Unattributable` because we've piled loss on top of loss.
+fn widen_attribution(a: Attribution) -> Attribution {
+    match a {
+        Attribution::Full => Attribution::WidenedScope,
+        _ => Attribution::Unattributable,
+    }
+}
+
+fn is_widening_function(name: &str) -> bool {
+    matches!(name, "descendants" | "children" | "repeat")
 }
 
 /// Set of positional selector function names that narrow cardinality to one.
@@ -446,6 +479,17 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
         }
     }
 
+    // Widening ops on any live anchor (including Start) enter Widened scope
+    // and demote attribution. Handled ahead of the main match so they compose
+    // cleanly regardless of the current anchor.
+    if let ChainStepKind::Function { name, .. } = &step.kind {
+        if is_widening_function(name) && !matches!(state.anchor, Anchor::Unattributable) {
+            state.attribution = widen_attribution(state.attribution);
+            state.anchor = Anchor::Widened;
+            return state;
+        }
+    }
+
     let next_anchor = match (&state.anchor, &step.kind) {
         // External constants (%context, %resource, %factory...) stay at Start.
         (Anchor::Start, ChainStepKind::External) => Anchor::Start,
@@ -470,6 +514,23 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
             state.link_ids.push(id.clone());
             Anchor::FilteredItems
         }
+
+        // Widened + where(linkId=…) — anchor drops into FilteredItems so we
+        // can still navigate to .answer.value, but attribution stays WidenedScope.
+        (
+            Anchor::Widened,
+            ChainStepKind::Function {
+                name,
+                link_id: Some(id),
+                ..
+            },
+        ) if name == "where" => {
+            state.link_ids.push(id.clone());
+            Anchor::FilteredItems
+        }
+
+        // Widened + "item" -> Items (still carrying widened attribution).
+        (Anchor::Widened, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
 
         // FilteredItems / Answer -> descend through .item (nested navigation)
         (Anchor::FilteredItems, ChainStepKind::Identifier(name)) if name == "item" => Anchor::Items,
@@ -558,10 +619,25 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
         // Any step on Unattributable keeps us Unattributable.
         (Anchor::Unattributable, _) => Anchor::Unattributable,
 
-        // Anything else walks off the lattice. If we were inside a QR scope,
-        // signal Unattributable so the caller emits a diagnostic; if we were
-        // still at Start, the chain simply doesn't apply to us.
+        // Anything else walks off our explicit map. Two cases:
+        //
+        // - Opaque function call (`iif`, `select`, non-linkId `where`, any
+        //   unrecognized function) on an attributed anchor: demote attribution
+        //   to Unattributable but keep the anchor. A subsequent
+        //   `.where(linkId=…)` can still collect linkIds, and a terminal
+        //   `.answer.value` still produces an annotation (attribution carries
+        //   the taint so consumers know not to fully trust it).
+        //
+        // - Anything else while in QR scope: hard stop to `Anchor::Unattributable`.
+        //
+        // - Anything while still at Start: non-QR chain — reset cleanly.
         _ => {
+            if state.is_attributed_anchor()
+                && matches!(&step.kind, ChainStepKind::Function { .. })
+            {
+                state.attribution = state.attribution.demote_to(Attribution::Unattributable);
+                return state; // anchor unchanged
+            }
             if state.in_qr_scope() {
                 Anchor::Unattributable
             } else {
@@ -596,17 +672,31 @@ fn match_qr_path(steps: &[ChainStep]) -> MatchOutcome {
     }
 
     match state.anchor {
-        Anchor::AnswerValue => MatchOutcome::Annotation(MatchResult {
-            link_ids: state.link_ids,
-            kind: MatchKind::AnswerRef(ValueAccessor::Value),
-            attribution: state.attribution,
-        }),
-        Anchor::AnswerValueProp(accessor) => MatchOutcome::Annotation(MatchResult {
-            link_ids: state.link_ids,
-            kind: MatchKind::AnswerRef(accessor),
-            attribution: state.attribution,
-        }),
+        Anchor::AnswerValue if !state.link_ids.is_empty() => {
+            MatchOutcome::Annotation(MatchResult {
+                link_ids: state.link_ids,
+                kind: MatchKind::AnswerRef(ValueAccessor::Value),
+                attribution: state.attribution,
+            })
+        }
+        Anchor::AnswerValueProp(accessor) if !state.link_ids.is_empty() => {
+            MatchOutcome::Annotation(MatchResult {
+                link_ids: state.link_ids,
+                kind: MatchKind::AnswerRef(accessor),
+                attribution: state.attribution,
+            })
+        }
         Anchor::FilteredItems if !state.link_ids.is_empty() => {
+            MatchOutcome::Annotation(MatchResult {
+                link_ids: state.link_ids,
+                kind: MatchKind::ItemRef,
+                attribution: state.attribution,
+            })
+        }
+        // Widened + collected linkIds is a valid ItemRef terminal (e.g.
+        // `item.where(linkId='g').children()`). Attribution carries the
+        // widening taint.
+        Anchor::Widened if !state.link_ids.is_empty() => {
             MatchOutcome::Annotation(MatchResult {
                 link_ids: state.link_ids,
                 kind: MatchKind::ItemRef,
@@ -1149,6 +1239,107 @@ mod tests {
         assert_eq!(annotations.len(), 1);
         assert_eq!(annotations[0].attribution, Attribution::Full);
         assert!(diagnostics.is_empty());
+    }
+
+    // ── Phase 2: widened scope & unattributable attributions ───────────
+
+    #[test]
+    fn test_descendants_widens_attribution() {
+        let r = annotate_expression(
+            "QuestionnaireResponse.descendants().where(linkId='x').answer.value",
+        )
+        .unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["x"] && *accessor == ValueAccessor::Value));
+        assert_eq!(r[0].attribution, Attribution::WidenedScope);
+    }
+
+    #[test]
+    fn test_children_on_group_produces_widened_item_ref() {
+        let r = annotate_expression("item.where(linkId='group1').children()").unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0].kind, AnnotationKind::ItemReference { link_ids }
+            if link_ids == &["group1"]));
+        assert_eq!(r[0].attribution, Attribution::WidenedScope);
+    }
+
+    #[test]
+    fn test_repeat_widens_attribution() {
+        let r = annotate_expression(
+            "item.where(linkId='g').repeat(item).where(linkId='x').answer.value",
+        )
+        .unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].attribution, Attribution::WidenedScope);
+    }
+
+    #[test]
+    fn test_opaque_where_in_middle_preserves_link_ids() {
+        let r = annotate_expression(
+            "item.where(linkId='x').answer.where(value.code = 'yes').item.where(linkId='y').answer.value",
+        )
+        .unwrap();
+        // The answer ref annotation preserves both linkIds, attribution tainted.
+        let ann = r
+            .iter()
+            .find(|a| matches!(&a.kind, AnnotationKind::AnswerReference { .. }))
+            .expect("expected an answer reference");
+        assert!(matches!(&ann.kind, AnnotationKind::AnswerReference { link_ids, .. }
+            if link_ids == &["x", "y"]));
+        assert_eq!(ann.attribution, Attribution::Unattributable);
+    }
+
+    #[test]
+    fn test_iif_without_terminal_emits_diagnostic() {
+        let (annotations, diagnostics) = annotate_expression_with_diagnostics(
+            "item.iif(linkId='x', answer.value, 'fallback')",
+        )
+        .unwrap();
+        assert!(annotations.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::ExpressionNotAttributable
+        );
+    }
+
+    #[test]
+    fn test_widened_attribution_skips_type_validation() {
+        use crate::analyze::{analyze_expression, AnalysisContext, DiagnosticCode};
+        use crate::analyze::questionnaire_index::QuestionnaireIndex;
+        use serde_json::json;
+
+        let q = json!({
+            "resourceType": "Questionnaire",
+            "item": [{"linkId": "bool1", "type": "boolean"}]
+        });
+        let idx = QuestionnaireIndex::build(&q);
+
+        // .code on a boolean is normally an error…
+        let direct = analyze_expression(
+            "item.where(linkId='bool1').answer.value.code",
+            &idx,
+            &AnalysisContext::default(),
+        )
+        .unwrap();
+        assert!(direct
+            .diagnostics
+            .iter()
+            .any(|d| d.code == DiagnosticCode::InvalidAccessorForType));
+
+        // …but when reached through descendants(), the path is no longer
+        // precisely modeled and we skip the type check.
+        let widened = analyze_expression(
+            "QuestionnaireResponse.descendants().where(linkId='bool1').answer.value.code",
+            &idx,
+            &AnalysisContext::default(),
+        )
+        .unwrap();
+        assert!(widened
+            .diagnostics
+            .iter()
+            .all(|d| d.code != DiagnosticCode::InvalidAccessorForType));
     }
 
     #[test]

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -43,23 +43,55 @@ pub enum AnnotationKind {
 
 /// How precisely an annotation attributes to its linkId scope.
 ///
-/// `Full` — the expression navigates to the complete set of answers/items
-/// for the named linkId(s).
+/// Ordered from most to least precise. Transitions only ever demote (never
+/// promote) — once a chain loses precision, it stays lost.
 ///
-/// `PartialPositional` — a positional selector (`first()`, `[i]`, etc.)
-/// narrowed the navigation to a subset. The linkId attribution still holds,
-/// but the evaluator sees fewer items than a bare `where(linkId=…)` would.
+/// - `Full` — the expression navigates to the complete set of answers/items
+///   for the named linkId(s).
+/// - `PartialPositional` — a positional selector (`first()`, `[i]`, `take(1)`, …)
+///   narrowed the navigation to a subset. The linkId attribution still holds,
+///   but the evaluator sees fewer items than a bare `where(linkId=…)` would.
+/// - `WidenedScope` — a scope-widening operator (`descendants()`, `children()`,
+///   `repeat()`) broke the structural parent-chain. linkIds are still known,
+///   but the path to them is no longer deterministic — parent-context
+///   reachability checks can't be trusted.
+/// - `Unattributable` — an opaque operation (`iif()`, `select()`, non-linkId
+///   `where(…)`, unknown function) severed precise attribution. linkIds
+///   collected up to that point are preserved but consumers should treat them
+///   as hints, not guarantees.
 #[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Attribution {
     #[default]
     Full,
     PartialPositional,
+    WidenedScope,
+    Unattributable,
 }
 
 impl Attribution {
     pub(crate) fn is_default(&self) -> bool {
         matches!(self, Attribution::Full)
+    }
+
+    /// Rank within the lattice. Higher = more precise.
+    fn rank(&self) -> u8 {
+        match self {
+            Attribution::Full => 3,
+            Attribution::PartialPositional => 2,
+            Attribution::WidenedScope => 1,
+            Attribution::Unattributable => 0,
+        }
+    }
+
+    /// Degrade `self` toward `floor`, never below.
+    /// Returns the lower-ranked of the two.
+    pub(crate) fn demote_to(self, floor: Attribution) -> Attribution {
+        if floor.rank() < self.rank() {
+            floor
+        } else {
+            self
+        }
     }
 }
 

--- a/src/analyze/validate_context.rs
+++ b/src/analyze/validate_context.rs
@@ -1,22 +1,38 @@
 use crate::analyze::{
-    Annotation, AnnotationKind, Diagnostic, DiagnosticCode, Severity, Span,
+    Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode, Severity, Span,
 };
 use crate::analyze::annotations::annotate_expression;
 use crate::analyze::questionnaire_index::QuestionnaireIndex;
 
-/// Extract the terminal linkId from annotations (prefers ItemReference).
-fn extract_target_link_id(annotations: &[Annotation]) -> Option<&str> {
+/// Extract the annotation we'd use to attribute the expression as a whole
+/// (prefers ItemReference, falls back to AnswerReference).
+fn extract_target_annotation(annotations: &[Annotation]) -> Option<&Annotation> {
     for ann in annotations {
-        if let AnnotationKind::ItemReference { link_ids } = &ann.kind {
-            return link_ids.last().map(|s| s.as_str());
+        if let AnnotationKind::ItemReference { .. } = &ann.kind {
+            return Some(ann);
         }
     }
     for ann in annotations {
-        if let AnnotationKind::AnswerReference { link_ids, .. } = &ann.kind {
-            return link_ids.last().map(|s| s.as_str());
+        if let AnnotationKind::AnswerReference { .. } = &ann.kind {
+            return Some(ann);
         }
     }
     None
+}
+
+fn annotation_link_ids(ann: &Annotation) -> &[String] {
+    match &ann.kind {
+        AnnotationKind::ItemReference { link_ids } => link_ids,
+        AnnotationKind::AnswerReference { link_ids, .. } => link_ids,
+        AnnotationKind::CodedValue { .. } => &[],
+    }
+}
+
+fn is_trusted_for_reachability(attribution: Attribution) -> bool {
+    matches!(
+        attribution,
+        Attribution::Full | Attribution::PartialPositional
+    )
 }
 
 /// Validate structural properties of item references in any expression.
@@ -63,29 +79,43 @@ pub(crate) fn validate_item_refs(
     }
 
     // Parent context reachability — check if this expression's item target
-    // is reachable from the parent scope
+    // is reachable from the parent scope. Skip when either side's attribution
+    // is degraded below PartialPositional: we'd be making claims about paths
+    // we no longer model precisely.
     if let Some(parent_expr) = parent_context_expr {
-        let target = extract_target_link_id(annotations);
-        if let Some(target_link_id) = target {
-            if !index.contains(target_link_id) {
-                return Ok(diagnostics);
-            }
-            let parent_annotations = annotate_expression(parent_expr)?;
-            if let Some(parent_link_id) = extract_target_link_id(&parent_annotations) {
-                if index.contains(parent_link_id)
-                    && !index.is_descendant(parent_link_id, target_link_id)
-                    && parent_link_id != target_link_id
-                {
-                    diagnostics.push(Diagnostic {
-                        span: Span { start: 0, end: expr.len() },
-                        severity: Severity::Error,
-                        code: DiagnosticCode::ContextUnreachableFromParent,
-                        message: format!(
-                            "Target '{}' is not reachable from parent context '{}'",
-                            target_link_id, parent_link_id
-                        ),
-                    });
-                }
+        let Some(target_ann) = extract_target_annotation(annotations) else {
+            return Ok(diagnostics);
+        };
+        if !is_trusted_for_reachability(target_ann.attribution) {
+            return Ok(diagnostics);
+        }
+        let Some(target_link_id) = annotation_link_ids(target_ann).last() else {
+            return Ok(diagnostics);
+        };
+        if !index.contains(target_link_id) {
+            return Ok(diagnostics);
+        }
+        let parent_annotations = annotate_expression(parent_expr)?;
+        let Some(parent_ann) = extract_target_annotation(&parent_annotations) else {
+            return Ok(diagnostics);
+        };
+        if !is_trusted_for_reachability(parent_ann.attribution) {
+            return Ok(diagnostics);
+        }
+        if let Some(parent_link_id) = annotation_link_ids(parent_ann).last() {
+            if index.contains(parent_link_id)
+                && !index.is_descendant(parent_link_id, target_link_id)
+                && parent_link_id != target_link_id
+            {
+                diagnostics.push(Diagnostic {
+                    span: Span { start: 0, end: expr.len() },
+                    severity: Severity::Error,
+                    code: DiagnosticCode::ContextUnreachableFromParent,
+                    message: format!(
+                        "Target '{}' is not reachable from parent context '{}'",
+                        target_link_id, parent_link_id
+                    ),
+                });
             }
         }
     }

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -22,6 +22,7 @@ fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
                 if let ChainStepKind::Function {
                     name,
                     link_id: Some(id),
+                    ..
                 } = &step.kind
                 {
                     if name == "where" {

--- a/src/analyze/validate_types.rs
+++ b/src/analyze/validate_types.rs
@@ -1,5 +1,5 @@
 use crate::analyze::{
-    Annotation, AnnotationKind, Diagnostic, DiagnosticCode, Severity, ValueAccessor,
+    Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode, Severity, ValueAccessor,
 };
 use crate::analyze::questionnaire_index::QuestionnaireIndex;
 
@@ -55,6 +55,16 @@ pub(crate) fn validate_value_types_from_annotations(
     let mut diagnostics = Vec::new();
 
     for ann in annotations {
+        // When attribution is degraded below PartialPositional, we're no longer
+        // confident the accessor is reached via the modeled path — the chain
+        // may have widened scope or passed through an opaque filter. Skip
+        // type-checking to avoid false-positive diagnostics.
+        if matches!(
+            ann.attribution,
+            Attribution::WidenedScope | Attribution::Unattributable
+        ) {
+            continue;
+        }
         if let AnnotationKind::AnswerReference { link_ids, accessor } = &ann.kind {
             let Some(last_link_id) = link_ids.last() else {
                 continue;

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -185,6 +185,8 @@ fn attribution_to_str(attribution: &Attribution) -> &'static str {
     match attribution {
         Attribution::Full => "full",
         Attribution::PartialPositional => "partial_positional",
+        Attribution::WidenedScope => "widened_scope",
+        Attribution::Unattributable => "unattributable",
     }
 }
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -246,6 +246,93 @@ def annotate_skip_alone_is_transparent_test():
     assert "attribution" not in result[0]
 
 
+# ── annotate_expression: widened scope & unattributable (Phase 2) ──────
+
+
+def annotate_descendants_widens_attribution_test():
+    result = annotate_expression(
+        "QuestionnaireResponse.descendants().where(linkId='x').answer.value"
+    )
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "answer_reference"
+    assert ann["link_ids"] == ["x"]
+    assert ann["attribution"] == "widened_scope"
+
+
+def annotate_children_produces_widened_item_ref_test():
+    result = annotate_expression("item.where(linkId='group1').children()")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "item_reference"
+    assert ann["link_ids"] == ["group1"]
+    assert ann["attribution"] == "widened_scope"
+
+
+def annotate_opaque_where_yields_unattributable_test():
+    result = annotate_expression(
+        "item.where(linkId='x').answer.where(value.code = 'yes')"
+        ".item.where(linkId='y').answer.value"
+    )
+    # LinkIds are preserved even though attribution is tainted.
+    ans_refs = [a for a in result if a["kind"] == "answer_reference"]
+    assert len(ans_refs) == 1
+    assert ans_refs[0]["link_ids"] == ["x", "y"]
+    assert ans_refs[0]["attribution"] == "unattributable"
+
+
+def annotate_iif_without_terminal_is_not_annotated_test():
+    result = annotate_expression("item.iif(linkId='x', answer.value, 'fallback')")
+    assert result == []
+
+
+# ── analyze_expression: validator gating on degraded attribution ──────
+
+
+def analyze_widened_skips_type_validation_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    # Direct path hits invalid_accessor_for_type.
+    direct = analyze_expression(
+        "item.where(linkId='bool1').answer.value.code", idx
+    )
+    assert any(d["code"] == "invalid_accessor_for_type" for d in direct["diagnostics"])
+
+    # Via descendants() — WidenedScope — type check must skip.
+    widened = analyze_expression(
+        "QuestionnaireResponse.descendants().where(linkId='bool1').answer.value.code",
+        idx,
+    )
+    assert all(
+        d["code"] != "invalid_accessor_for_type" for d in widened["diagnostics"]
+    )
+
+
+def analyze_widened_skips_context_reachability_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    # Without descendants(), group2 is unreachable from group1 parent scope.
+    unreachable = analyze_expression(
+        "item.where(linkId='group2')",
+        idx,
+        parent_context_expr="%resource.item.where(linkId='group1')",
+    )
+    assert any(
+        d["code"] == "context_unreachable_from_parent"
+        for d in unreachable["diagnostics"]
+    )
+
+    # With descendants() on the target side, attribution is WidenedScope —
+    # reachability check must be skipped.
+    via_descendants = analyze_expression(
+        "QuestionnaireResponse.descendants().where(linkId='group2')",
+        idx,
+        parent_context_expr="%resource.item.where(linkId='group1')",
+    )
+    assert all(
+        d["code"] != "context_unreachable_from_parent"
+        for d in via_descendants["diagnostics"]
+    )
+
+
 # ── analyze_expression ─────────────────────────────────────────────────
 
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -201,6 +201,51 @@ def annotate_full_attribution_not_emitted_for_clean_chain_test():
     assert "attribution" not in result[0]
 
 
+# ── annotate_expression: context variables & composite positional (Phase 3)
+
+
+def annotate_this_dot_link_id_in_where_test():
+    # `$this.linkId = 'x'` inside where() is equivalent to `linkId = 'x'`.
+    result = annotate_expression("item.where($this.linkId = 'x').answer.value")
+    assert len(result) == 1
+    ann = result[0]
+    assert ann["kind"] == "answer_reference"
+    assert ann["link_ids"] == ["x"]
+    # Full attribution preserved — wire shape omits the attribution key.
+    assert "attribution" not in ann
+
+
+def annotate_skip_zero_take_one_demotes_test():
+    result = annotate_expression("item.where(linkId='x').answer.skip(0).take(1).value")
+    assert len(result) == 1
+    assert result[0]["attribution"] == "partial_positional"
+
+
+def annotate_skip_one_take_two_preserves_attribution_test():
+    # `.skip(1).take(2)` leaves cardinality at Many → attribution stays Full.
+    result = annotate_expression("item.where(linkId='x').answer.skip(1).take(2).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
+def annotate_take_one_demotes_test():
+    result = annotate_expression("item.where(linkId='x').answer.take(1).value")
+    assert len(result) == 1
+    assert result[0]["attribution"] == "partial_positional"
+
+
+def annotate_take_many_is_transparent_test():
+    result = annotate_expression("item.where(linkId='x').answer.take(5).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
+def annotate_skip_alone_is_transparent_test():
+    result = annotate_expression("item.where(linkId='x').answer.skip(3).value")
+    assert len(result) == 1
+    assert "attribution" not in result[0]
+
+
 # ── analyze_expression ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #37.

## Summary

Completes the selection-state lattice from #36 / #38 with two new attribution levels and a new anchor. Chains that previously got dropped as \`ExpressionNotAttributable\` now resolve to tainted-but-useful annotations.

**New attributions** (serialized snake_case):
- \`widened_scope\` — after \`descendants()\` / \`children()\` / \`repeat()\`. LinkIds still known, but the structural parent-chain is gone.
- \`unattributable\` — after non-linkId \`where(…)\`, \`iif\`, \`select\`, or any unrecognized function. Chain keeps navigating and collecting linkIds; the terminal annotation preserves them so consumers can decide what to trust.

**New anchor**: \`Anchor::Widened\` is a valid terminal for \`ItemReference\` when linkIds were collected before the widening step (e.g. \`item.where(linkId='g').children()\`).

**Validator gating**:
- \`validate_types\` skips \`WidenedScope\` and \`Unattributable\` annotations (the accessor may be reached via a path we didn't model).
- \`validate_context\` parent-reachability check skips when either side is degraded below \`PartialPositional\`.

**Monotonic demotion**: \`Attribution::demote_to\` ensures a chain never regains precision. Stacking a widen on an already-positional chain jumps straight to \`Unattributable\`.

## Wire compatibility

Additive. \`Full\` attribution continues to omit the \`attribution\` key (v3.0.0 byte-identical). New strings \`widened_scope\` / \`unattributable\` only appear when the lattice has degraded.

## Depends on

- #36 (Phase 1) — merged in via PR #40 in the base branch
- #38 (Phase 3) — merged in via PR #41 in the base branch

This PR is the final piece of the three-phase rewrite sketched in #39. Branched off Phase 3; rebases trivially once the earlier PRs merge.

## Test plan

- [x] \`cargo test --lib\` — 77 pass (6 new Phase 2 cases added)
- [x] \`uv run pytest tests/test_analyze.py\` — 39 pass (6 new Phase 2 cases)
- [x] \`uv run pytest\` full suite — 1757 pass
- [x] \`cargo check\` for default, \`--features python\`, and \`--no-default-features --features wasm --target wasm32-unknown-unknown\`
- [x] Regression check: all Phase 1 and Phase 3 tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)