### PR TITLE
fix(wasm): drop _rust.d.ts from npm publish (closes #44)

### DIFF
--- a/wasm/package.json
+++ b/wasm/package.json
@@ -11,7 +11,6 @@
   "files": [
     "_rust_bg.wasm",
     "_rust.js",
-    "_rust.d.ts",
     "fhirpath_wasm.d.ts"
   ],
   "main": "_rust.js",


### PR DESCRIPTION
## Summary

Closes #44.

The wasm package shipped two `.d.ts` files that redeclared the same symbols:
- `_rust.d.ts` — auto-generated by `wasm-bindgen`, returns typed as `any`.
- `fhirpath_wasm.d.ts` — hand-authored overlay with the proper types.

Strict-mode TS resolvers could pick up the auto-generated file first and emit duplicate-declaration errors or fall back to `any`. This PR drops `_rust.d.ts` from `wasm/package.json#files` so only the overlay is published — single source of truth.

`wasm-pack build` still emits `pkg/_rust.d.ts` locally; `npm publish` honors `files`, so it just doesn't end up in the tarball. `package.json#types` already points at the overlay, so npm consumers get the right types.

## Tradeoff

This is option (a) from the issue. It does **not** preserve the vendoring path where consumers copy only the wasm-bindgen default outputs (`_rust.js`, `_rust.d.ts`, `_rust_bg.wasm`) and expect typed APIs — they'd get no `.d.ts` at all and fall back to untyped imports. We discussed this and decided that scenario isn't real for this package; if it becomes real, switching to option (b) is a one-line workflow change.

## Test plan

- [ ] Locally: `wasm-pack build --target web --features wasm --no-default-features && cp wasm/package.json pkg/package.json && cp wasm/fhirpath_wasm.d.ts pkg/fhirpath_wasm.d.ts && (cd pkg && npm pack --dry-run)` — confirm `_rust.d.ts` is **not** in the listed files.
- [ ] Smoke test in a consumer: import `annotate_expression` from `@tiro-health/fhirpath-wasm` and check `r[0].kind.type` autocompletes after publishing a prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)