### PR TITLE
feat(wasm): emit UTF-16 span offsets for JS hosts

### DIFF
--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -3,6 +3,26 @@
 use wasm_bindgen::prelude::*;
 
 use crate::analyze;
+use crate::utf16::byte_to_utf16_offset;
+
+/// Translate a span's byte offsets into UTF-16 code-unit offsets so JS hosts
+/// can use them directly for `String.slice`, CodeMirror diagnostics, etc.
+fn convert_span(span: &mut analyze::Span, expr: &str) {
+    span.start = byte_to_utf16_offset(expr, span.start);
+    span.end = byte_to_utf16_offset(expr, span.end);
+}
+
+fn convert_annotation_spans(annotations: &mut [analyze::Annotation], expr: &str) {
+    for ann in annotations.iter_mut() {
+        convert_span(&mut ann.span, expr);
+    }
+}
+
+fn convert_diagnostic_spans(diagnostics: &mut [analyze::Diagnostic], expr: &str) {
+    for diag in diagnostics.iter_mut() {
+        convert_span(&mut diag.span, expr);
+    }
+}
 
 /// Parse a FHIRPath expression string into an AST.
 ///
@@ -16,11 +36,14 @@ pub fn parse(expr: &str) -> Result<JsValue, JsError> {
 /// Annotate a FHIRPath expression, extracting answer references,
 /// item references, and coded values.
 ///
-/// Returns `Annotation[]` as a JavaScript value.
+/// Returns `Annotation[]` as a JavaScript value. Span offsets are
+/// UTF-16 code units, suitable for `String.prototype.slice` and
+/// CodeMirror/Monaco position math.
 #[wasm_bindgen]
 pub fn annotate_expression(expr: &str) -> Result<JsValue, JsError> {
-    let annotations =
+    let mut annotations =
         analyze::annotate_expression(expr).map_err(|e| JsError::new(&e.to_string()))?;
+    convert_annotation_spans(&mut annotations, expr);
     serde_wasm_bindgen::to_value(&annotations).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -66,6 +89,8 @@ pub fn resolve_context(expr: &str, base_expr: &str) -> Result<String, JsError> {
 /// Analyze a FHIRPath expression in the context of a Questionnaire.
 ///
 /// Returns `{ annotations: Annotation[], diagnostics: Diagnostic[] }`.
+/// Span offsets are UTF-16 code units, suitable for
+/// `String.prototype.slice` and CodeMirror/Monaco position math.
 ///
 /// - `expr` -- the FHIRPath expression string
 /// - `index` -- a `QuestionnaireIndex` built from the Questionnaire
@@ -82,7 +107,9 @@ pub fn analyze_expression(
         scope_link_id,
         parent_context_expr,
     };
-    let result = analyze::analyze_expression(expr, &index.inner, &context)
+    let mut result = analyze::analyze_expression(expr, &index.inner, &context)
         .map_err(|e| JsError::new(&e.to_string()))?;
+    convert_annotation_spans(&mut result.annotations, expr);
+    convert_diagnostic_spans(&mut result.diagnostics, expr);
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bindings;
 pub mod lexer;
 pub mod parser;
 pub mod resolve;
+pub mod utf16;
 
 pub use lexer::{Token, TokenKind};
 pub use parser::AstNode;

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -1,0 +1,84 @@
+//! Byte-offset → UTF-16 code-unit-offset conversion.
+//!
+//! The lexer/parser produces byte offsets into the source string, which is the
+//! natural unit in Rust. JavaScript strings are UTF-16-indexed, so byte offsets
+//! cannot be used directly with `String.prototype.slice`, CodeMirror diagnostics,
+//! or any other JS-side text decoration. The wasm boundary uses these helpers
+//! to translate spans before serializing them out.
+
+/// Convert a byte offset within `s` into a UTF-16 code-unit offset.
+///
+/// `byte_offset` should land on a UTF-8 char boundary; if it does not, the
+/// returned offset is the UTF-16 position of the next char boundary at or
+/// after `byte_offset`. Offsets at or past `s.len()` saturate at the total
+/// UTF-16 length.
+pub fn byte_to_utf16_offset(s: &str, byte_offset: usize) -> usize {
+    let mut utf16 = 0;
+    for (i, c) in s.char_indices() {
+        if i >= byte_offset {
+            return utf16;
+        }
+        utf16 += c.len_utf16();
+    }
+    utf16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_offsets_pass_through() {
+        let s = "item.where(linkId='abc').answer.value";
+        assert_eq!(byte_to_utf16_offset(s, 0), 0);
+        assert_eq!(byte_to_utf16_offset(s, 4), 4);
+        assert_eq!(byte_to_utf16_offset(s, s.len()), s.len());
+    }
+
+    #[test]
+    fn two_byte_char_counts_as_one_utf16_unit() {
+        // 'ç' is U+00E7: 2 UTF-8 bytes, 1 UTF-16 code unit.
+        let s = "façade";
+        assert_eq!(s.len(), 7); // 6 chars, but ç is 2 bytes
+        assert_eq!(byte_to_utf16_offset(s, 0), 0);
+        assert_eq!(byte_to_utf16_offset(s, 2), 2); // 'fa' = 2 bytes / 2 utf16
+        assert_eq!(byte_to_utf16_offset(s, 4), 3); // 'faç' = 4 bytes / 3 utf16
+        assert_eq!(byte_to_utf16_offset(s, 7), 6); // full string
+    }
+
+    #[test]
+    fn supplementary_plane_char_counts_as_two_utf16_units() {
+        // '😀' is U+1F600: 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair).
+        let s = "a😀b";
+        assert_eq!(s.len(), 6);
+        assert_eq!(byte_to_utf16_offset(s, 1), 1); // 'a'
+        assert_eq!(byte_to_utf16_offset(s, 5), 3); // 'a😀'
+        assert_eq!(byte_to_utf16_offset(s, 6), 4); // full string
+    }
+
+    #[test]
+    fn offset_past_end_saturates() {
+        let s = "abc";
+        assert_eq!(byte_to_utf16_offset(s, 100), 3);
+    }
+
+    #[test]
+    fn slicing_a_substring_with_unicode() {
+        // Mirrors the issue's acceptance criterion: a JS host doing
+        // `expr.slice(start, end)` over UTF-16 indices should land on the
+        // intended byte-range substring.
+        let expr = "item.where(linkId='façade').answer.value";
+        let needle = "linkId='façade'";
+        let byte_start = expr.find(needle).unwrap();
+        let byte_end = byte_start + needle.len();
+
+        let utf16_start = byte_to_utf16_offset(expr, byte_start);
+        let utf16_end = byte_to_utf16_offset(expr, byte_end);
+
+        // Reproduce JS-side slicing by walking UTF-16 code units.
+        let utf16_units: Vec<u16> = expr.encode_utf16().collect();
+        let sliced = String::from_utf16(&utf16_units[utf16_start..utf16_end]).unwrap();
+
+        assert_eq!(sliced, needle);
+    }
+}

--- a/wasm/fhirpath_wasm.d.ts
+++ b/wasm/fhirpath_wasm.d.ts
@@ -1,4 +1,10 @@
-/** Byte offset range within the original FHIRPath expression string. */
+/**
+ * UTF-16 code-unit offset range within the original FHIRPath expression string.
+ *
+ * Indices are aligned with JavaScript string semantics, so they can be passed
+ * directly to `String.prototype.slice`, `substring`, or CodeMirror / Monaco
+ * position APIs without further translation.
+ */
 export interface Span {
   start: number;
   end: number;


### PR DESCRIPTION
## Summary

Fixes #45. The wasm bindings now emit UTF-16 code-unit offsets in `Span.start` / `Span.end`, so JS hosts can use them directly with `String.prototype.slice`, CodeMirror diagnostics, Monaco markers, etc. Pure-Rust / PyO3 consumers continue to see byte offsets — the conversion happens only at the wasm boundary.

## What changed

- New `src/utf16.rs` — `byte_to_utf16_offset` helper, with unit tests covering ASCII pass-through, 2-byte chars (`ç`), supplementary-plane chars / surrogate pairs (`😀`), past-end saturation, and an end-to-end "slice over Unicode expression" test mirroring the issue's `façade` acceptance example.
- `src/bindings/wasm.rs` — `annotate_expression` and `analyze_expression` walk annotations and diagnostics before serialization and rewrite each `Span` from byte → UTF-16 offsets. Doc comments updated.
- `wasm/fhirpath_wasm.d.ts` — `Span` JSDoc updated to document UTF-16 semantics and JS-string compatibility.
- `src/lib.rs` — register the new `utf16` module.

## Why this approach (option (a) from the issue)

- Purely additive at the public API — no new fields, no breaking change for either Rust or JS consumers (vs. the issue's options (b)/(c)).
- Single conversion site at the boundary; the rest of the analyzer keeps thinking in bytes.
- Conversion is O(n) per offset on the input string. FHIRPath expressions are short (typically <200 chars) and per-call annotation/diagnostic counts are small, so the cost is negligible. Easy to upgrade to a single-pass converter later if benchmarks ever demand it.

## Test plan

- [x] `cargo test --no-default-features` — 116 passed (5 new utf16 tests).
- [x] `cargo build --features wasm --no-default-features --target wasm32-unknown-unknown` — clean.
- [ ] Smoke-test in a downstream JS host: `expr.slice(ann.span.start, ann.span.end)` lands on the intended substring for an expression containing non-ASCII content (e.g. `item.where(linkId='façade').answer.value`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)