### PR TITLE
feat(analyze): tighten external constants and emit root completions

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -26,7 +26,11 @@ pub(crate) enum ChainStepKind {
         /// Used to reason about cardinality in composite positional ops.
         integer_arg: Option<i64>,
     },
-    External,
+    /// FHIRPath external constant (`%name`). The state machine only treats
+    /// `%resource` and `%context` as transparent QR-aliases; other names
+    /// (e.g. `%questionnaire`, `%ucum`) point at unrelated resources and
+    /// must not silently inherit QR navigation semantics.
+    External(String),
     /// `$this` / `$index` / `$total` — FHIRPath context variables.
     /// The specific identity is currently only used for debugging; the state
     /// machine treats all three as transparent pass-throughs at Start.
@@ -214,9 +218,9 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                         return None;
                     }
                     let ident = ext_const.children.first()?;
-                    let _name = get_identifier_name(ident)?;
+                    let name = get_identifier_name(ident)?.to_string();
                     Some(vec![ChainStep {
-                        kind: ChainStepKind::External,
+                        kind: ChainStepKind::External(name),
                         link_id_span: None,
                     }])
                 }
@@ -491,8 +495,16 @@ fn transition(mut state: SelectionState, step: &ChainStep) -> SelectionState {
     }
 
     let next_anchor = match (&state.anchor, &step.kind) {
-        // External constants (%context, %resource, %factory...) stay at Start.
-        (Anchor::Start, ChainStepKind::External) => Anchor::Start,
+        // Only %resource and %context are transparent QR-aliases. Other
+        // externals (%questionnaire, %ucum, %vs-*, …) point at unrelated
+        // resources, so any subsequent navigation is not QR navigation and
+        // must not produce QR-style annotations.
+        (Anchor::Start, ChainStepKind::External(name))
+            if name == "resource" || name == "context" =>
+        {
+            Anchor::Start
+        }
+        (Anchor::Start, ChainStepKind::External(_)) => Anchor::Unattributable,
 
         // Context variables ($this / $index / $total) at Start stay at Start —
         // they're transparent pass-throughs for navigation recognition. Real
@@ -667,7 +679,15 @@ fn match_qr_path(steps: &[ChainStep]) -> MatchOutcome {
             ever_in_qr_scope = true;
         }
         if matches!(state.anchor, Anchor::Unattributable) {
-            return MatchOutcome::Unattributable;
+            // Only flag as Unattributable when the chain actually entered QR
+            // territory at some point — otherwise it's a non-QR chain (e.g.
+            // `%questionnaire.item.…` or `Patient.name`) and should fall
+            // through silently so the AST walker can recurse normally.
+            return if ever_in_qr_scope {
+                MatchOutcome::Unattributable
+            } else {
+                MatchOutcome::NotApplicable
+            };
         }
     }
 

--- a/src/analyze/completions.rs
+++ b/src/analyze/completions.rs
@@ -24,6 +24,9 @@ pub struct CompletionItem {
 // ── Context resolution ─────────────────────────────────────────────────
 
 enum ContextPosition {
+    /// Top of the QuestionnaireResponse — the user typed just `%resource`
+    /// (or `%context`) and wants to start drilling into items.
+    Root,
     ItemFiltered(String),
     Answer(String),
 }
@@ -40,6 +43,10 @@ fn resolve_context(expr: &str) -> Result<Option<ContextPosition>, crate::ParseEr
 
     enum State {
         Start,
+        /// Saw `%resource` / `%context` at the head of the chain with nothing
+        /// after it yet. Equivalent to Start for navigation, but distinguished
+        /// so a chain that ends here can emit root-level suggestions.
+        AtRoot,
         Item,
         ItemFiltered(String),
         Answer(String),
@@ -49,8 +56,16 @@ fn resolve_context(expr: &str) -> Result<Option<ContextPosition>, crate::ParseEr
 
     for step in &steps {
         state = match (&state, &step.kind) {
-            (State::Start, ChainStepKind::External) => State::Start,
-            (State::Start, ChainStepKind::Identifier(name)) if name == "item" => State::Item,
+            // Only %resource and %context are transparent QR-aliases — see
+            // annotations.rs for the same restriction.
+            (State::Start, ChainStepKind::External(name))
+                if name == "resource" || name == "context" =>
+            {
+                State::AtRoot
+            }
+            (State::Start | State::AtRoot, ChainStepKind::Identifier(name)) if name == "item" => {
+                State::Item
+            }
             (
                 State::Item,
                 ChainStepKind::Function {
@@ -71,6 +86,7 @@ fn resolve_context(expr: &str) -> Result<Option<ContextPosition>, crate::ParseEr
     }
 
     match state {
+        State::AtRoot => Ok(Some(ContextPosition::Root)),
         State::ItemFiltered(id) => Ok(Some(ContextPosition::ItemFiltered(id))),
         State::Answer(id) => Ok(Some(ContextPosition::Answer(id))),
         _ => Ok(None),
@@ -218,6 +234,12 @@ pub fn generate_completions(
     let mut counter: usize = 0;
 
     match position {
+        ContextPosition::Root => {
+            for child_id in index.roots() {
+                let prefix = format!("item.where(linkId='{child_id}')");
+                emit_subtree(index, child_id, &prefix, &[], &mut counter, &mut out);
+            }
+        }
         ContextPosition::ItemFiltered(ref link_id) => {
             let Some(info) = index.get(link_id) else {
                 return Ok(Vec::new());
@@ -493,6 +515,46 @@ mod tests {
         assert!(!items.is_empty());
         let texts: Vec<&str> = items.iter().map(|c| c.insert_text.as_str()).collect();
         assert!(texts.contains(&"item.where(linkId='choice1').answer.value"));
+    }
+
+    #[test]
+    fn test_resource_alone_emits_top_level_items() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "%resource").unwrap();
+
+        assert!(!items.is_empty());
+        let texts: Vec<&str> = items.iter().map(|c| c.insert_text.as_str()).collect();
+        // Top-level group: descend through children (group itself has no value).
+        assert!(texts.contains(&"item.where(linkId='group1').item.where(linkId='choice1').answer.value"));
+        // Top-level coding item: own answer.value plus child completions.
+        assert!(texts.contains(&"item.where(linkId='coding-with-children').answer.value"));
+        assert!(texts.contains(&"item.where(linkId='coding-with-children').answer.value.code"));
+    }
+
+    #[test]
+    fn test_context_alone_emits_top_level_items() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "%context").unwrap();
+        assert!(!items.is_empty());
+        let texts: Vec<&str> = items.iter().map(|c| c.insert_text.as_str()).collect();
+        assert!(texts.contains(&"item.where(linkId='coding-with-children').answer.value"));
+    }
+
+    #[test]
+    fn test_questionnaire_external_returns_empty() {
+        // %questionnaire points at the Questionnaire structure, not the QR —
+        // suggesting QR-shaped completions there would be misleading.
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items =
+            generate_completions(&idx, "%questionnaire.item.where(linkId='group1')").unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_unknown_external_alone_returns_empty() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "%questionnaire").unwrap();
+        assert!(items.is_empty());
     }
 
     #[test]

--- a/src/analyze/questionnaire_index.rs
+++ b/src/analyze/questionnaire_index.rs
@@ -16,6 +16,10 @@ pub struct QuestionnaireItemInfo {
 #[derive(Debug, Default)]
 pub struct QuestionnaireIndex {
     items: HashMap<String, QuestionnaireItemInfo>,
+    /// Top-level item linkIds in document order. Iterating the `items`
+    /// HashMap doesn't preserve order, so we keep a parallel list to drive
+    /// deterministic suggestion output.
+    root_link_ids: Vec<String>,
 }
 
 impl QuestionnaireIndex {
@@ -27,6 +31,11 @@ impl QuestionnaireIndex {
             index.walk(items, None);
         }
         index
+    }
+
+    /// Top-level item linkIds in document order.
+    pub fn roots(&self) -> &[String] {
+        &self.root_link_ids
     }
 
     fn walk(&mut self, items: &[serde_json::Value], parent_link_id: Option<&str>) {
@@ -80,11 +89,13 @@ impl QuestionnaireIndex {
                 },
             );
 
-            // Update parent's children vec
+            // Update parent's children vec, or record this as a root.
             if let Some(pid) = parent_link_id {
                 if let Some(parent) = self.items.get_mut(pid) {
                     parent.children.push(link_id.clone());
                 }
+            } else {
+                self.root_link_ids.push(link_id.clone());
             }
 
             if let Some(sub_items) = item.get("item").and_then(|v| v.as_array()) {


### PR DESCRIPTION
## Summary

- **Tighten external-constant handling** in both annotation and completion resolution. Only `%resource` and `%context` are treated as transparent QuestionnaireResponse aliases. Other externals (`%questionnaire`, `%ucum`, `%vs-*`, …) point at unrelated resources, and previously their use as a chain prefix silently inherited QR navigation semantics — emitting QR-shaped annotations or completions that did not correspond to the target resource.
- **Emit root completions** when the user types just `%resource` (or `%context`) on its own. Clients can now drive autocomplete from the QR root without forcing users to first type `.item.where(linkId=…)`.

## Behavior changes

| Expression | Before | After |
|---|---|---|
| `%resource.item.where(linkId='X')` | works | works (unchanged) |
| `%context.item.where(linkId='X')` | works | works (unchanged) |
| `%questionnaire.item.where(linkId='X')` | annotated as QR navigation (incorrect) | empty / unattributable |
| `%resource` (alone) | empty | top-level item completions |
| `%context` (alone) | empty | top-level item completions |
| `%questionnaire` (alone) | empty | empty (unchanged) |

## Implementation notes

- `ChainStepKind::External` now carries the constant name (`External(String)`).
- The annotation state machine routes non-allowed externals at `Anchor::Start` to `Anchor::Unattributable`. The early-return in `match_qr_path` was updated so a chain that never entered QR scope (e.g. `%questionnaire.item.…`, `Patient.name`) returns `NotApplicable` rather than emitting an `ExpressionNotAttributable` diagnostic.
- `QuestionnaireIndex` now tracks top-level link IDs in document order via a parallel `root_link_ids: Vec<String>`, exposed as `roots()` for deterministic root-level completion output.
- Completion resolver gains a `State::AtRoot` / `ContextPosition::Root`, fed into the existing `emit_subtree` recursion.

## Test plan

- [x] `cargo test --lib` — 170 unit tests pass, including 4 new completion tests:
  - `test_resource_alone_emits_top_level_items`
  - `test_context_alone_emits_top_level_items`
  - `test_questionnaire_external_returns_empty`
  - `test_unknown_external_alone_returns_empty`
- [x] All existing annotation / attribution tests still green (verified that `%context.item.where(...)` annotation tests at `annotations.rs:1035` and `annotations.rs:1076` continue to pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)