### PR TITLE
feat(analyze): surface inferred_type and inferred_cardinality in public API

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -274,6 +274,13 @@ pub struct AnalysisContext {
 pub struct ExpressionAnalysis {
     pub annotations: Vec<Annotation>,
     pub diagnostics: Vec<Diagnostic>,
+    /// Inferred result type of the expression. `Unknown` when inference
+    /// cannot determine the type with confidence — UI hosts should treat
+    /// it as "no information" rather than "any type".
+    pub inferred_type: InferredType,
+    /// Inferred cardinality of the expression's result. `Unknown` when
+    /// inference cannot determine the cardinality with confidence.
+    pub inferred_cardinality: Cardinality,
 }
 
 /// Analyze a FHIRPath expression in the context of a Questionnaire.
@@ -312,11 +319,15 @@ pub fn analyze_expression(
         index,
     )?);
 
-    // 4. Result-type inference — only when caller declares an expected type.
-    //    Silent on `Unknown` (conservative); fires only on definite mismatch.
+    // 4. Result-type and cardinality inference — always run so callers can
+    //    use the values for UI metadata (hover, badges, …). Diagnostics fire
+    //    only when an expected_* is set and inference produces a definite,
+    //    conflicting result. `Unknown` is silent.
+    let inferred_type = result_type::infer_result_type(&ast, &ann, index);
+    let inferred_cardinality = result_type::infer_cardinality(&ast, &ann, index);
+
     if let Some(expected) = context.expected_result_type {
-        let inferred = result_type::infer_result_type(&ast, &ann, index);
-        if inferred != InferredType::Unknown && inferred != expected {
+        if inferred_type != InferredType::Unknown && inferred_type != expected {
             diagnostics.push(Diagnostic {
                 span: Span {
                     start: ast.byte_start,
@@ -326,18 +337,15 @@ pub fn analyze_expression(
                 code: DiagnosticCode::ExpressionTypeMismatch,
                 message: format!(
                     "Expression evaluates to {} but {} was expected",
-                    inferred_type_name(inferred),
+                    inferred_type_name(inferred_type),
                     inferred_type_name(expected),
                 ),
             });
         }
     }
 
-    // 5. Cardinality inference — same shape as type inference. Mismatch only
-    //    fires when both expected and inferred are definite and disagree.
     if let Some(expected) = context.expected_cardinality {
-        let inferred = result_type::infer_cardinality(&ast, &ann, index);
-        if inferred != Cardinality::Unknown && inferred != expected {
+        if inferred_cardinality != Cardinality::Unknown && inferred_cardinality != expected {
             diagnostics.push(Diagnostic {
                 span: Span {
                     start: ast.byte_start,
@@ -347,7 +355,7 @@ pub fn analyze_expression(
                 code: DiagnosticCode::ExpressionCardinalityMismatch,
                 message: format!(
                     "Expression yields {} but {} was expected",
-                    cardinality_name(inferred),
+                    cardinality_name(inferred_cardinality),
                     cardinality_name(expected),
                 ),
             });
@@ -357,6 +365,8 @@ pub fn analyze_expression(
     Ok(ExpressionAnalysis {
         annotations: ann,
         diagnostics,
+        inferred_type,
+        inferred_cardinality,
     })
 }
 
@@ -688,6 +698,32 @@ mod tests {
             .diagnostics
             .iter()
             .all(|d| d.code != DiagnosticCode::ExpressionCardinalityMismatch));
+    }
+
+    // ── inferred_type / inferred_cardinality on result ──
+
+    #[test]
+    fn result_exposes_inferred_type_and_cardinality_without_expectations() {
+        let idx = QuestionnaireIndex::build(&questionnaire_with_repeats());
+        let result = analyze_expression(
+            "item.where(linkId='multi').answer.value",
+            &idx,
+            &AnalysisContext::default(),
+        ).unwrap();
+        assert_eq!(result.inferred_type, InferredType::Coding);
+        assert_eq!(result.inferred_cardinality, Cardinality::Collection);
+    }
+
+    #[test]
+    fn result_exposes_unknown_when_inference_cannot_determine() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let result = analyze_expression(
+            "Patient.name.given",
+            &idx,
+            &AnalysisContext::default(),
+        ).unwrap();
+        assert_eq!(result.inferred_type, InferredType::Unknown);
+        assert_eq!(result.inferred_cardinality, Cardinality::Unknown);
     }
 
     #[test]

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -263,6 +263,29 @@ fn resolve_context(expr: &str, base_expr: &str) -> PyResult<String> {
         .map_err(|e| pyo3::exceptions::PySyntaxError::new_err(e.0))
 }
 
+fn inferred_type_to_str(t: &InferredType) -> &'static str {
+    match t {
+        InferredType::Boolean => "boolean",
+        InferredType::String => "string",
+        InferredType::Integer => "integer",
+        InferredType::Decimal => "decimal",
+        InferredType::Date => "date",
+        InferredType::DateTime => "date_time",
+        InferredType::Time => "time",
+        InferredType::Quantity => "quantity",
+        InferredType::Coding => "coding",
+        InferredType::Unknown => "unknown",
+    }
+}
+
+fn cardinality_to_str(c: &Cardinality) -> &'static str {
+    match c {
+        Cardinality::Singleton => "singleton",
+        Cardinality::Collection => "collection",
+        Cardinality::Unknown => "unknown",
+    }
+}
+
 /// Map an `InferredType` snake_case string to the enum.
 fn parse_inferred_type(s: &str) -> Option<InferredType> {
     match s {
@@ -344,6 +367,11 @@ fn analyze_expression(
     let dict = PyDict::new(py);
     dict.set_item("annotations", PyList::new(py, annotations)?)?;
     dict.set_item("diagnostics", PyList::new(py, diagnostics)?)?;
+    dict.set_item("inferred_type", inferred_type_to_str(&result.inferred_type))?;
+    dict.set_item(
+        "inferred_cardinality",
+        cardinality_to_str(&result.inferred_cardinality),
+    )?;
     Ok(dict.into())
 }
 

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -113,7 +113,11 @@ fn parse_cardinality(s: &str) -> Option<analyze::Cardinality> {
 
 /// Analyze a FHIRPath expression in the context of a Questionnaire.
 ///
-/// Returns `{ annotations: Annotation[], diagnostics: Diagnostic[] }`.
+/// Returns `{ annotations: Annotation[], diagnostics: Diagnostic[],
+/// inferred_type: string, inferred_cardinality: string }`. The inferred
+/// fields are snake_case enum values (`"boolean"`, `"coding"`,
+/// `"singleton"`, `"collection"`, `"unknown"`, …) and are filled
+/// unconditionally — UI hosts can use them for hover/badge metadata.
 /// Span offsets are UTF-16 code units, suitable for
 /// `String.prototype.slice` and CodeMirror/Monaco position math.
 ///

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -430,3 +430,36 @@ def analyze_expression_not_attributable_test():
     assert diag["severity"] == "info"
     # No annotation because the chain is unattributable.
     assert result["annotations"] == []
+
+
+# ── Inferred type / cardinality (UI metadata) ──────────────────────────
+
+
+def analyze_returns_inferred_type_and_cardinality_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='bool1').answer.value",
+        idx,
+    )
+    assert result["inferred_type"] == "boolean"
+    assert result["inferred_cardinality"] == "singleton"
+
+
+def analyze_returns_unknown_when_inference_cannot_determine_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression("Patient.name.given", idx)
+    assert result["inferred_type"] == "unknown"
+    assert result["inferred_cardinality"] == "unknown"
+
+
+def analyze_inferred_fields_present_alongside_diagnostics_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    result = analyze_expression(
+        "item.where(linkId='bool1').answer.value",
+        idx,
+        expected_result_type="string",
+    )
+    # Validation diagnostic still fires...
+    assert any(d["code"] == "expression_type_mismatch" for d in result["diagnostics"])
+    # ...and the inferred values are still surfaced for UI use.
+    assert result["inferred_type"] == "boolean"

--- a/wasm/fhirpath_wasm.d.ts
+++ b/wasm/fhirpath_wasm.d.ts
@@ -10,6 +10,44 @@ export interface Span {
   end: number;
 }
 
+/**
+ * Inferred result type of a FHIRPath expression.
+ *
+ * `unknown` means the analyzer could not determine the type with confidence —
+ * UI hosts should treat it as "no information" rather than "any type".
+ */
+export type InferredType =
+  | "boolean"
+  | "string"
+  | "integer"
+  | "decimal"
+  | "date"
+  | "date_time"
+  | "time"
+  | "quantity"
+  | "coding"
+  | "unknown";
+
+/**
+ * Inferred cardinality of a FHIRPath expression's result.
+ *
+ * `unknown` means the analyzer could not determine the cardinality with
+ * confidence.
+ */
+export type Cardinality = "singleton" | "collection" | "unknown";
+
+/**
+ * How precisely an annotation attributes to its linkId scope.
+ *
+ * Omitted on the wire when `full` (the precise default) — only present when
+ * a positional selector or scope-widening / opaque op has degraded precision.
+ */
+export type Attribution =
+  | "full"
+  | "partial_positional"
+  | "widened_scope"
+  | "unattributable";
+
 export type AnnotationKind =
   | {
       type: "answer_reference";
@@ -27,18 +65,41 @@ export type AnnotationKind =
 export interface Annotation {
   span: Span;
   kind: AnnotationKind;
+  /** Present only when not `"full"`. */
+  attribution?: Attribution;
 }
+
+export type DiagnosticCode =
+  | "unknown_link_id"
+  | "unreachable_link_id"
+  | "invalid_accessor_for_type"
+  | "missing_accessor_for_coding"
+  | "item_reference_targets_leaf"
+  | "context_unreachable_from_parent"
+  | "expression_not_attributable"
+  | "expression_type_mismatch"
+  | "expression_cardinality_mismatch";
 
 export interface Diagnostic {
   span: Span;
-  severity: "error" | "warning";
-  code: string;
+  severity: "error" | "warning" | "info";
+  code: DiagnosticCode;
   message: string;
 }
 
 export interface AnalysisResult {
   annotations: Annotation[];
   diagnostics: Diagnostic[];
+  /**
+   * Inferred result type of the expression. Always populated; `"unknown"`
+   * when inference can't determine the type with confidence.
+   */
+  inferred_type: InferredType;
+  /**
+   * Inferred cardinality of the expression's result. Always populated;
+   * `"unknown"` when inference can't determine the cardinality with confidence.
+   */
+  inferred_cardinality: Cardinality;
 }
 
 /** Parse a FHIRPath expression string into an AST object. */
@@ -63,15 +124,33 @@ export class QuestionnaireIndex {
 }
 
 /**
+ * Resolve `%context` references in a FHIRPath expression at the AST level.
+ *
+ * Parses both expressions, replaces every `%context` reference in `expr` with
+ * the parsed `base_expr` AST, and returns the serialized result. Returns
+ * `expr` unchanged when no `%context` reference exists.
+ */
+export function resolve_context(expr: string, base_expr: string): string;
+
+/**
  * Analyze a FHIRPath expression in the context of a Questionnaire.
  *
- * Returns annotations and validation diagnostics.
+ * Returns annotations, validation diagnostics, and the inferred result type
+ * and cardinality. The inferred fields are filled unconditionally and are
+ * suitable for UI metadata (hover, badges).
+ *
+ * `expected_result_type` and `expected_cardinality` are validation hints —
+ * when set, the analyzer emits `expression_type_mismatch` /
+ * `expression_cardinality_mismatch` on a definite mismatch. `"unknown"`
+ * inference results are silent.
  */
 export function analyze_expression(
   expr: string,
   index: QuestionnaireIndex,
   scope_link_id?: string,
   parent_context_expr?: string,
+  expected_result_type?: InferredType,
+  expected_cardinality?: Cardinality,
 ): AnalysisResult;
 
 export type InitInput =


### PR DESCRIPTION
## Summary

- Add `inferred_type` and `inferred_cardinality` fields to `ExpressionAnalysis`, populated unconditionally so hosts can display them as UI metadata (hover popups, badges, status pills) without having to force a mismatch diagnostic.
- Expose both fields through the Python and WASM bindings as snake_case enum strings (`\"boolean\"`, `\"coding\"`, `\"singleton\"`, `\"collection\"`, `\"unknown\"`, …).
- Existing diagnostic emission is unchanged: a mismatch only fires when the caller declares an `expected_*` and inference produces a definite, conflicting result.

## Semantics

- `inferred_type = \"unknown\"` and `inferred_cardinality = \"unknown\"` mean inference could not determine the value with confidence. UI hosts should treat them as \"no information\", not \"any type\".

## Test plan

- [x] `cargo test --lib` — 168 unit tests pass, including 2 new tests in `analyze::tests`:
  - `result_exposes_inferred_type_and_cardinality_without_expectations`
  - `result_exposes_unknown_when_inference_cannot_determine`
- [x] `uv run pytest tests/test_analyze.py` — 42 tests pass, including 3 new ones covering the Python binding surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)