### PR TITLE
feat(analyze): expose link_id and item_type on CompletionItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- `CompletionItem` now exposes `link_id` and `item_type` fields (#51)
 - WASM target: `@tiro-health/fhirpath-wasm` via wasm-bindgen (#13)
 - Analysis API via PyO3: `annotate_expression()`, `analyze_expression()`, `QuestionnaireIndex` (#12)
 - SDC expression analysis with annotation extraction (#7)

--- a/src/analyze/completions.rs
+++ b/src/analyze/completions.rs
@@ -19,6 +19,8 @@ pub struct CompletionItem {
     pub filter_text: String,
     pub sort_text: String,
     pub kind: CompletionItemKind,
+    pub link_id: String,
+    pub item_type: String,
 }
 
 // ── Context resolution ─────────────────────────────────────────────────
@@ -143,6 +145,8 @@ fn emit_value_completions(
         filter_text: filter_text.clone(),
         sort_text: format!("{:04}", *counter),
         kind: CompletionItemKind::Value,
+        link_id: link_id.to_string(),
+        item_type: item_type.to_string(),
     });
     *counter += 1;
 
@@ -154,6 +158,8 @@ fn emit_value_completions(
             filter_text: filter_text.clone(),
             sort_text: format!("{:04}", *counter),
             kind: CompletionItemKind::Code,
+            link_id: link_id.to_string(),
+            item_type: item_type.to_string(),
         });
         *counter += 1;
 
@@ -164,6 +170,8 @@ fn emit_value_completions(
             filter_text,
             sort_text: format!("{:04}", *counter),
             kind: CompletionItemKind::Display,
+            link_id: link_id.to_string(),
+            item_type: item_type.to_string(),
         });
         *counter += 1;
     }
@@ -611,5 +619,50 @@ mod tests {
             .find(|c| c.insert_text == "item.where(linkId='choice1').answer.value.display")
             .unwrap();
         assert_eq!(display.kind, CompletionItemKind::Display);
+    }
+
+    #[test]
+    fn test_link_id_and_item_type_match_target_item() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "item.where(linkId='group1')").unwrap();
+
+        let bool_item = items
+            .iter()
+            .find(|c| c.insert_text == "item.where(linkId='bool1').answer.value")
+            .unwrap();
+        assert_eq!(bool_item.link_id, "bool1");
+        assert_eq!(bool_item.item_type, "boolean");
+    }
+
+    #[test]
+    fn test_coding_variants_share_link_id_and_item_type() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "item.where(linkId='group1')").unwrap();
+
+        let variants: Vec<&CompletionItem> = items
+            .iter()
+            .filter(|c| c.link_id == "choice1")
+            .collect();
+        assert_eq!(variants.len(), 3);
+        for v in &variants {
+            assert_eq!(v.link_id, "choice1");
+            assert_eq!(v.item_type, "choice");
+        }
+    }
+
+    #[test]
+    fn test_nested_descent_uses_leaf_link_id() {
+        let idx = QuestionnaireIndex::build(&questionnaire());
+        let items = generate_completions(&idx, "item.where(linkId='group1')").unwrap();
+
+        let deep = items
+            .iter()
+            .find(|c| {
+                c.insert_text
+                    == "item.where(linkId='subgroup').item.where(linkId='deep-string').answer.value"
+            })
+            .unwrap();
+        assert_eq!(deep.link_id, "deep-string");
+        assert_eq!(deep.item_type, "string");
     }
 }

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -145,6 +145,8 @@ fn completion_item_to_pydict(py: Python<'_>, item: &analyze::CompletionItem) -> 
     dict.set_item("filter_text", item.filter_text.as_str())?;
     dict.set_item("sort_text", item.sort_text.as_str())?;
     dict.set_item("kind", completion_kind_to_str(&item.kind))?;
+    dict.set_item("link_id", item.link_id.as_str())?;
+    dict.set_item("item_type", item.item_type.as_str())?;
     Ok(dict.into())
 }
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -97,6 +97,25 @@ def questionnaire_index_invalid_json_test():
         QuestionnaireIndex("not valid json")
 
 
+def questionnaire_index_generate_completions_exposes_link_id_and_item_type_test():
+    idx = QuestionnaireIndex(QUESTIONNAIRE_JSON)
+    items = idx.generate_completions("item.where(linkId='group1')")
+    assert items, "expected at least one completion for a populated group"
+
+    bool_item = next(
+        item
+        for item in items
+        if item["insert_text"] == "item.where(linkId='bool1').answer.value"
+    )
+    assert bool_item["link_id"] == "bool1"
+    assert bool_item["item_type"] == "boolean"
+
+    choice_variants = [item for item in items if item["link_id"] == "choice1"]
+    assert len(choice_variants) == 3
+    for variant in choice_variants:
+        assert variant["item_type"] == "choice"
+
+
 # ── annotate_expression ────────────────────────────────────────────────
 
 

--- a/wasm/fhirpath_wasm.d.ts
+++ b/wasm/fhirpath_wasm.d.ts
@@ -115,6 +115,8 @@ export interface CompletionItem {
   filter_text: string;
   sort_text: string;
   kind: "value" | "code" | "display";
+  link_id: string;
+  item_type: string;
 }
 
 /** Index built from a FHIR Questionnaire, used for expression analysis. */


### PR DESCRIPTION
Closes #51.

## Summary

- Adds `link_id` and `item_type` fields to `CompletionItem` (returned by `QuestionnaireIndex.generate_completions`).
- Wires the new fields through the Python (`completion_item_to_pydict`) and WASM (auto via `serde_wasm_bindgen`) bindings; updates the hand-maintained `wasm/fhirpath_wasm.d.ts`.
- Adds 3 Rust unit tests + 1 Python smoke test pinning the new shape.

## Why

UI consumers (Lexical-based FHIRPath editor in `sdc-extract-composition/viewer`) need the underlying Questionnaire `linkId` and `item.type` per completion to:

1. Filter out `group` items from autocomplete (groups have no `.answer`, so chaining `.answer.value` would be invalid).
2. Surface item metadata (type, future required/repeats flags) without re-parsing `insert_text` (brittle) or calling `annotate_expression` per item (O(n) extra round-trips on every keystroke).

Both fields were already known to the emitter — `emit_value_completions` receives `link_id: &str` and `item_type: &str` as parameters — they just weren't propagated.

## Design notes

**Non-optional `String` (not `Option<String>`).** Every current emit path produces an item-derived completion; there are zero call sites that would yield `None`. The issue's hedge "rare entry-point completions can leave them empty/null" is forward-looking — if a future change ever emits a non-item completion, widening to `Option` is a one-line change at the same time. Avoiding speculative `Option` keeps consumer code from having to handle a state that cannot occur.

**No change to `src/bindings/wasm.rs`** — `serde_wasm_bindgen::to_value(&items)` propagates new fields automatically via the existing `Serialize` derive.

## Test plan

- [x] `cargo test --lib` — 175/175 pass (20 in `analyze::completions`, including 3 new: `test_link_id_and_item_type_match_target_item`, `test_coding_variants_share_link_id_and_item_type`, `test_nested_descent_uses_leaf_link_id`)
- [x] `uv run pytest tests/test_analyze.py` — 43/43 pass, including the new `questionnaire_index_generate_completions_exposes_link_id_and_item_type_test`
- [ ] WASM rebuild + spot-check that runtime JSON matches the updated `.d.ts` (deferred to reviewer's local build)

## Reviewer notes

- The full `cargo test` (not `--lib`) hits a pre-existing macOS/PyO3 link error when building the integration-test binary against Python symbols — unrelated to this change. Library tests cover all the relevant code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)