### PR TITLE
refactor(parser): produce typed Expr; lower to AstNode for FFI compat (Phase 2+3)

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -4,7 +4,7 @@
 /// (e.g. `item.where(linkId='x').answer.value.code`).
 /// Pass 2 identifies coded values in equality/equivalence comparisons against those references.
 
-use crate::parser::AstNode;
+use crate::compat::AstNode;
 
 use super::{Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode, Severity, Span, ValueAccessor};
 
@@ -993,7 +993,8 @@ pub(crate) fn annotate_expression_with_ast(
 ) -> Result<(AstNode, Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
     let tokens = crate::lexer::tokenize(expr)?;
     let mut p = crate::parser::Parser::new(&tokens);
-    let root = p.parse_entire_expression()?;
+    let typed = p.parse_entire_expression()?;
+    let root = crate::compat::lower(&typed, &tokens);
 
     let mut answer_refs = Vec::new();
     let mut diagnostics = Vec::new();

--- a/src/analyze/completions.rs
+++ b/src/analyze/completions.rs
@@ -43,7 +43,8 @@ enum ContextPosition {
 fn resolve_context(expr: &str) -> Result<Option<ContextPosition>, crate::ParseError> {
     let tokens = crate::lexer::tokenize(expr)?;
     let mut p = crate::parser::Parser::new(&tokens);
-    let root = p.parse_entire_expression()?;
+    let typed = p.parse_entire_expression()?;
+    let root = crate::compat::lower(&typed, &tokens);
 
     let steps = match decompose_chain(&root) {
         Some(s) => s,

--- a/src/analyze/result_type.rs
+++ b/src/analyze/result_type.rs
@@ -14,7 +14,7 @@ use crate::analyze::questionnaire_index::QuestionnaireIndex;
 use crate::analyze::{
     Annotation, AnnotationKind, Attribution, Cardinality, InferredType, ValueAccessor,
 };
-use crate::parser::AstNode;
+use crate::compat::AstNode;
 
 /// Map a Questionnaire item type + value-accessor to an inferred result type.
 ///

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -1,7 +1,7 @@
 use crate::analyze::annotations::{decompose_chain, ChainStepKind};
 use crate::analyze::questionnaire_index::QuestionnaireIndex;
 use crate::analyze::{Diagnostic, DiagnosticCode, Severity, Span};
-use crate::parser::AstNode;
+use crate::compat::AstNode;
 
 /// Collect all linkIds referenced in where(linkId='...') clauses throughout the AST.
 /// Returns Vec of (linkId_value, span_of_the_literal).
@@ -54,7 +54,8 @@ pub(crate) fn validate_link_ids_from_expr(
 ) -> Result<Vec<Diagnostic>, crate::ParseError> {
     let tokens = crate::lexer::tokenize(expr)?;
     let mut parser = crate::parser::Parser::new(&tokens);
-    let root = parser.parse_entire_expression()?;
+    let typed = parser.parse_entire_expression()?;
+    let root = crate::compat::lower(&typed, &tokens);
 
     Ok(validate_link_ids_from_ast(&root, index, scope_link_id))
 }

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -391,8 +391,5 @@ pub fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// Internal helper: parse and also return the token stream (needed for text computation).
 fn rust_parse_with_tokens(expr: &str) -> Result<(AstNode, Vec<Token>), crate::ParseError> {
-    let tokens = crate::lexer::tokenize(expr)?;
-    let mut p = crate::parser::Parser::new(&tokens);
-    let ast = p.parse_entire_expression()?;
-    Ok((ast, tokens))
+    crate::parse_with_compat(expr)
 }

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -29,7 +29,7 @@ fn convert_diagnostic_spans(diagnostics: &mut [analyze::Diagnostic], expr: &str)
 /// Returns the AST as a JavaScript object.
 #[wasm_bindgen]
 pub fn parse(expr: &str) -> Result<JsValue, JsError> {
-    let ast = crate::parse(expr).map_err(|e| JsError::new(&e.to_string()))?;
+    let (ast, _) = crate::parse_with_compat(expr).map_err(|e| JsError::new(&e.to_string()))?;
     serde_wasm_bindgen::to_value(&ast).map_err(|e| JsError::new(&e.to_string()))
 }
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -20,9 +20,51 @@
 
 use serde_json::{json, Map, Value};
 
+use crate::ast::{
+    BinOp, Expr, ExternalConstantId, Identifier, Invocation, Literal, QualifiedIdentifier,
+    TypeSpecifier, Unit,
+};
 use crate::lexer::{tokenize, Token};
-use crate::parser::{AstNode, Parser};
-use crate::ParseError;
+use crate::parser::Parser;
+use crate::{ParseError, Span};
+
+/// Legacy ANTLR-shaped AST node. Produced by the lowering layer
+/// (`compat::lower`) from the typed `Expr` tree, then consumed by the
+/// Python/WASM bindings, the analyze passes, and `resolve.rs`.
+///
+/// This is the FFI contract: the dict shape produced by `lower_to_compat_json`
+/// is what Python's `fhirpathpy` consumers see, and the snapshot tests
+/// gate it byte-for-byte.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AstNode {
+    pub node_type: &'static str,
+    pub terminal_node_text: Vec<String>,
+    pub children: Vec<AstNode>,
+    /// Index range [token_start..token_end] into the token vec (for text computation).
+    pub token_start: usize,
+    pub token_end: usize,
+    /// Byte offsets into the source string.
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+impl AstNode {
+    /// Construct an empty `AstNode` whose token-range and byte-range start at
+    /// the given token index. The `token_end` and `byte_end` are seeded to the
+    /// same start position; callers are expected to widen the range as they
+    /// build subnodes.
+    pub fn new(node_type: &'static str, token_start: usize, tokens: &[Token]) -> Self {
+        AstNode {
+            node_type,
+            terminal_node_text: Vec::new(),
+            children: Vec::new(),
+            token_start,
+            token_end: token_start,
+            byte_start: tokens[token_start].byte_start,
+            byte_end: tokens[token_start].byte_start,
+        }
+    }
+}
 
 /// Lower an AST node + its tokens into the Python-binding-shape JSON dict.
 pub fn lower_to_compat_json(node: &AstNode, tokens: &[Token]) -> Value {
@@ -58,13 +100,356 @@ pub fn lower_to_compat_json(node: &AstNode, tokens: &[Token]) -> Value {
 /// `{"children": [lower_to_compat_json(&ast, &tokens)]}`.
 pub fn parse_to_compat_json(expr: &str) -> Result<Value, ParseError> {
     let tokens = tokenize(expr)?;
-    let ast = Parser::new(&tokens).parse_entire_expression()?;
+    let expr_ast = Parser::new(&tokens).parse_entire_expression()?;
+    let ast = lower(&expr_ast, &tokens);
     let mut root = Map::new();
     root.insert(
         "children".to_string(),
         Value::Array(vec![lower_to_compat_json(&ast, &tokens)]),
     );
     Ok(Value::Object(root))
+}
+
+// ── Lowering layer: typed Expr → legacy ANTLR-shaped AstNode ─────────────
+
+/// Lower a typed `Expr` (produced by the parser) into the legacy
+/// ANTLR-shaped `AstNode` tree consumed by the bindings, the analyze
+/// passes, and `resolve.rs`.
+pub fn lower(expr: &Expr, tokens: &[Token]) -> AstNode {
+    lower_expr(expr, tokens)
+}
+
+fn lower_expr(expr: &Expr, tokens: &[Token]) -> AstNode {
+    match expr {
+        Expr::Binary { op, lhs, rhs, span } => AstNode {
+            node_type: bin_op_node_type(*op),
+            terminal_node_text: vec![op.keyword().to_string()],
+            children: vec![lower_expr(lhs, tokens), lower_expr(rhs, tokens)],
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Expr::Polarity { op, operand, span } => AstNode {
+            node_type: "PolarityExpression",
+            terminal_node_text: vec![op.keyword().to_string()],
+            children: vec![lower_expr(operand, tokens)],
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Expr::Type {
+            lhs,
+            op,
+            type_spec,
+            span,
+        } => AstNode {
+            node_type: "TypeExpression",
+            terminal_node_text: vec![op.keyword().to_string()],
+            children: vec![lower_expr(lhs, tokens), lower_type_specifier(type_spec)],
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Expr::Indexer {
+            receiver,
+            index,
+            span,
+        } => AstNode {
+            node_type: "IndexerExpression",
+            terminal_node_text: vec!["[".to_string(), "]".to_string()],
+            children: vec![lower_expr(receiver, tokens), lower_expr(index, tokens)],
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Expr::Invocation {
+            receiver: Some(rcv),
+            call,
+            span,
+        } => AstNode {
+            node_type: "InvocationExpression",
+            terminal_node_text: vec![".".to_string()],
+            children: vec![lower_expr(rcv, tokens), lower_invocation(call, tokens)],
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Expr::Invocation {
+            receiver: None,
+            call,
+            span,
+        } => {
+            let inner = lower_invocation(call, tokens);
+            let inv_term = wrap(span, "InvocationTerm", inner);
+            wrap(span, "TermExpression", inv_term)
+        }
+        Expr::Parenthesized { inner, span } => {
+            let par = AstNode {
+                node_type: "ParenthesizedTerm",
+                terminal_node_text: vec!["(".to_string(), ")".to_string()],
+                children: vec![lower_expr(inner, tokens)],
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            };
+            wrap(span, "TermExpression", par)
+        }
+        Expr::Literal(lit) => {
+            let span = literal_span(lit);
+            let lit_node = lower_literal(lit);
+            let lit_term = wrap(span, "LiteralTerm", lit_node);
+            wrap(span, "TermExpression", lit_term)
+        }
+        Expr::ExternalConstant { ident, span } => {
+            let id_node = lower_external_constant_id(ident);
+            let ec = AstNode {
+                node_type: "ExternalConstant",
+                terminal_node_text: vec!["%".to_string()],
+                children: vec![id_node],
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            };
+            let ec_term = wrap(span, "ExternalConstantTerm", ec);
+            wrap(span, "TermExpression", ec_term)
+        }
+    }
+}
+
+/// Wrap a single child in a span-matching parent node with the given node_type.
+fn wrap(span: &Span, node_type: &'static str, child: AstNode) -> AstNode {
+    AstNode {
+        node_type,
+        terminal_node_text: Vec::new(),
+        children: vec![child],
+        token_start: span.token_start,
+        token_end: span.token_end,
+        byte_start: span.byte_start,
+        byte_end: span.byte_end,
+    }
+}
+
+fn lower_invocation(inv: &Invocation, tokens: &[Token]) -> AstNode {
+    match inv {
+        Invocation::Member { ident } => AstNode {
+            node_type: "MemberInvocation",
+            terminal_node_text: Vec::new(),
+            children: vec![lower_identifier(ident)],
+            token_start: ident.span.token_start,
+            token_end: ident.span.token_end,
+            byte_start: ident.span.byte_start,
+            byte_end: ident.span.byte_end,
+        },
+        Invocation::Function { name, args, span } => {
+            let mut functn_children = vec![lower_identifier(name)];
+            if !args.is_empty() {
+                let first_span = expr_span(&args[0]);
+                let last_span = expr_span(args.last().unwrap());
+                let pl_tnt: Vec<String> =
+                    (0..args.len().saturating_sub(1)).map(|_| ",".to_string()).collect();
+                let pl_children: Vec<AstNode> =
+                    args.iter().map(|a| lower_expr(a, tokens)).collect();
+                let paramlist = AstNode {
+                    node_type: "ParamList",
+                    terminal_node_text: pl_tnt,
+                    children: pl_children,
+                    token_start: first_span.token_start,
+                    token_end: last_span.token_end,
+                    byte_start: first_span.byte_start,
+                    byte_end: last_span.byte_end,
+                };
+                functn_children.push(paramlist);
+            }
+            let functn = AstNode {
+                node_type: "Functn",
+                terminal_node_text: vec!["(".to_string(), ")".to_string()],
+                children: functn_children,
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            };
+            AstNode {
+                node_type: "FunctionInvocation",
+                terminal_node_text: Vec::new(),
+                children: vec![functn],
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            }
+        }
+        Invocation::This { span } => leaf("ThisInvocation", "$this", span),
+        Invocation::Index { span } => leaf("IndexInvocation", "$index", span),
+        Invocation::Total { span } => leaf("TotalInvocation", "$total", span),
+    }
+}
+
+fn leaf(node_type: &'static str, text: &str, span: &Span) -> AstNode {
+    AstNode {
+        node_type,
+        terminal_node_text: vec![text.to_string()],
+        children: Vec::new(),
+        token_start: span.token_start,
+        token_end: span.token_end,
+        byte_start: span.byte_start,
+        byte_end: span.byte_end,
+    }
+}
+
+fn lower_literal(lit: &Literal) -> AstNode {
+    match lit {
+        Literal::Null { span } => AstNode {
+            node_type: "NullLiteral",
+            terminal_node_text: vec!["{".to_string(), "}".to_string()],
+            children: Vec::new(),
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Literal::Boolean { value, span } => leaf(
+            "BooleanLiteral",
+            if *value { "true" } else { "false" },
+            span,
+        ),
+        Literal::String { raw, span } => leaf("StringLiteral", raw, span),
+        Literal::Number { raw, span } => leaf("NumberLiteral", raw, span),
+        Literal::DateTime { raw, span } => leaf("DateTimeLiteral", raw, span),
+        Literal::Time { raw, span } => leaf("TimeLiteral", raw, span),
+        Literal::Quantity {
+            number,
+            unit,
+            span,
+        } => {
+            let unit_node = lower_unit(unit);
+            let quantity = AstNode {
+                node_type: "Quantity",
+                terminal_node_text: vec![number.clone()],
+                children: vec![unit_node],
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            };
+            AstNode {
+                node_type: "QuantityLiteral",
+                terminal_node_text: Vec::new(),
+                children: vec![quantity],
+                token_start: span.token_start,
+                token_end: span.token_end,
+                byte_start: span.byte_start,
+                byte_end: span.byte_end,
+            }
+        }
+    }
+}
+
+fn lower_unit(unit: &Unit) -> AstNode {
+    match unit {
+        Unit::String { raw, span } => AstNode {
+            node_type: "Unit",
+            terminal_node_text: vec![raw.clone()],
+            children: Vec::new(),
+            token_start: span.token_start,
+            token_end: span.token_end,
+            byte_start: span.byte_start,
+            byte_end: span.byte_end,
+        },
+        Unit::DateTimePrecision { word, span } => {
+            let inner = leaf("DateTimePrecision", word, span);
+            wrap(span, "Unit", inner)
+        }
+        Unit::PluralDateTimePrecision { word, span } => {
+            let inner = leaf("PluralDateTimePrecision", word, span);
+            wrap(span, "Unit", inner)
+        }
+    }
+}
+
+fn lower_external_constant_id(ext: &ExternalConstantId) -> AstNode {
+    match ext {
+        ExternalConstantId::Identifier(id) => lower_identifier(id),
+        ExternalConstantId::String { raw, span } => leaf("Identifier", raw, span),
+    }
+}
+
+fn lower_identifier(id: &Identifier) -> AstNode {
+    leaf("Identifier", &id.raw, &id.span)
+}
+
+fn lower_type_specifier(ts: &TypeSpecifier) -> AstNode {
+    let qi = lower_qualified_identifier(&ts.qualified);
+    AstNode {
+        node_type: "TypeSpecifier",
+        terminal_node_text: Vec::new(),
+        children: vec![qi],
+        token_start: ts.span.token_start,
+        token_end: ts.span.token_end,
+        byte_start: ts.span.byte_start,
+        byte_end: ts.span.byte_end,
+    }
+}
+
+fn lower_qualified_identifier(qi: &QualifiedIdentifier) -> AstNode {
+    let dot_count = qi.parts.len().saturating_sub(1);
+    let tnt: Vec<String> = (0..dot_count).map(|_| ".".to_string()).collect();
+    let children: Vec<AstNode> = qi.parts.iter().map(lower_identifier).collect();
+    AstNode {
+        node_type: "QualifiedIdentifier",
+        terminal_node_text: tnt,
+        children,
+        token_start: qi.span.token_start,
+        token_end: qi.span.token_end,
+        byte_start: qi.span.byte_start,
+        byte_end: qi.span.byte_end,
+    }
+}
+
+fn bin_op_node_type(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Implies => "ImpliesExpression",
+        BinOp::Or | BinOp::Xor => "OrExpression",
+        BinOp::And => "AndExpression",
+        BinOp::In | BinOp::Contains => "MembershipExpression",
+        BinOp::Eq | BinOp::NotEq | BinOp::EquivTilde | BinOp::NotEquivTilde => "EqualityExpression",
+        BinOp::Lt | BinOp::Gt | BinOp::LtEq | BinOp::GtEq => "InequalityExpression",
+        BinOp::Union => "UnionExpression",
+        BinOp::Plus | BinOp::Minus | BinOp::Concat => "AdditiveExpression",
+        BinOp::Mul | BinOp::TrueDiv | BinOp::IntDiv | BinOp::Mod => "MultiplicativeExpression",
+    }
+}
+
+fn expr_span(expr: &Expr) -> &Span {
+    match expr {
+        Expr::Binary { span, .. }
+        | Expr::Polarity { span, .. }
+        | Expr::Type { span, .. }
+        | Expr::Indexer { span, .. }
+        | Expr::Invocation { span, .. }
+        | Expr::Parenthesized { span, .. }
+        | Expr::ExternalConstant { span, .. } => span,
+        Expr::Literal(lit) => literal_span(lit),
+    }
+}
+
+fn literal_span(lit: &Literal) -> &Span {
+    match lit {
+        Literal::Null { span }
+        | Literal::Boolean { span, .. }
+        | Literal::String { span, .. }
+        | Literal::Number { span, .. }
+        | Literal::Quantity { span, .. }
+        | Literal::DateTime { span, .. }
+        | Literal::Time { span, .. } => span,
+    }
 }
 
 /// Returns `true` for node types whose dict gets a `"text"` field.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,26 @@ pub mod parser;
 pub mod resolve;
 pub mod utf16;
 
+pub use ast::Expr;
+pub use compat::AstNode;
 pub use lexer::{Token, TokenKind};
-pub use parser::AstNode;
 
 use lexer::tokenize;
 use parser::Parser;
 
-/// Byte offset range into the source string.
+/// Byte offset range into the source string, plus the corresponding
+/// half-open token-index range `[token_start..token_end)` into the lexer's
+/// token vector. The token range is what the lowering layer (Phase 3) uses to
+/// reproduce the legacy `AstNode` tree's `compute_text` output.
+///
+/// Error sites that don't have a meaningful token position can leave
+/// `token_start == token_end == 0`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct Span {
     pub byte_start: usize,
     pub byte_end: usize,
+    pub token_start: usize,
+    pub token_end: usize,
 }
 
 /// Typed parse error for the FHIRPath lexer + parser.
@@ -140,11 +149,23 @@ impl std::fmt::Display for ParseError {
 
 impl std::error::Error for ParseError {}
 
-/// Parse a FHIRPath expression string into an AST.
-pub fn parse(expr: &str) -> Result<AstNode, ParseError> {
+/// Parse a FHIRPath expression string into a typed `Expr` tree.
+pub fn parse(expr: &str) -> Result<Expr, ParseError> {
     let tokens = tokenize(expr)?;
     let mut p = Parser::new(&tokens);
     p.parse_entire_expression()
+}
+
+/// Parse a FHIRPath expression and lower it to the legacy ANTLR-shaped
+/// `AstNode` tree, returning both the lowered tree and the underlying
+/// token vector. Callers that need `compute_text` or other token-aware
+/// behavior should use this; new code should prefer [`parse`].
+pub fn parse_with_compat(expr: &str) -> Result<(AstNode, Vec<Token>), ParseError> {
+    let tokens = tokenize(expr)?;
+    let mut p = Parser::new(&tokens);
+    let expr_ast = p.parse_entire_expression()?;
+    let ast = compat::lower(&expr_ast, &tokens);
+    Ok((ast, tokens))
 }
 
 // Re-export the PyO3 module entry point when the python feature is enabled.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,34 +1,22 @@
-/// FHIRPath recursive-descent parser: &[Token] → AstNode tree
+//! FHIRPath recursive-descent parser: `&[Token]` → typed `Expr` tree.
+//!
+//! The parser produces the typed `Expr` enum from `crate::ast`. The lowering
+//! layer in `crate::compat::lower` walks `Expr` and produces the legacy
+//! `AstNode` ANTLR-shaped tree consumed by the bindings, the analyze passes,
+//! and `resolve.rs`.
+//!
+//! Each `Expr`/`Invocation`/`Identifier`/etc. carries a `Span` covering both
+//! the byte range and the half-open token-index range `[token_start..token_end)`.
+//! The lowering layer relies on the token range to populate
+//! `AstNode::token_start/token_end`, which `compat::compute_text` uses to
+//! reconstruct the legacy `text` field.
 
+use crate::ast::{
+    BinOp, Expr, ExternalConstantId, Identifier, Invocation, Literal, QualifiedIdentifier,
+    TypeOp, TypeSpecifier, Unit, UnaryOp,
+};
 use crate::lexer::{Token, TokenKind};
 use crate::{ParseError, Span};
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct AstNode {
-    pub node_type: &'static str,
-    pub terminal_node_text: Vec<String>,
-    pub children: Vec<AstNode>,
-    /// Index range [token_start..token_end] into the token vec (for text computation).
-    pub token_start: usize,
-    pub token_end: usize,
-    /// Byte offsets into the source string.
-    pub byte_start: usize,
-    pub byte_end: usize,
-}
-
-impl AstNode {
-    fn new(node_type: &'static str, token_start: usize, tokens: &[Token]) -> Self {
-        AstNode {
-            node_type,
-            terminal_node_text: Vec::new(),
-            children: Vec::new(),
-            token_start,
-            token_end: token_start,
-            byte_start: tokens[token_start].byte_start,
-            byte_end: tokens[token_start].byte_start,
-        }
-    }
-}
 
 pub struct Parser<'a> {
     tokens: &'a [Token],
@@ -63,32 +51,45 @@ impl<'a> Parser<'a> {
                 expected: kind,
                 found: tok.kind,
                 found_text: tok.text.clone(),
-                span: Span {
-                    byte_start: tok.byte_start,
-                    byte_end: tok.byte_end,
-                },
+                span: self.token_span(tok),
             })
         }
     }
 
-    fn set_end(&self, node: &mut AstNode) {
-        node.token_end = self.pos;
-        node.byte_end = self.tokens[self.pos.saturating_sub(1)].byte_end;
+    /// Build a `Span` covering a single token (used for error diagnostics).
+    fn token_span(&self, tok: &Token) -> Span {
+        Span {
+            byte_start: tok.byte_start,
+            byte_end: tok.byte_end,
+            token_start: 0,
+            token_end: 0,
+        }
+    }
+
+    /// Build a `Span` covering tokens `[token_start..self.pos)`. Assumes at
+    /// least one token has been consumed since `token_start`.
+    fn span_from(&self, token_start: usize) -> Span {
+        let token_end = self.pos;
+        let byte_start = self.tokens[token_start].byte_start;
+        let byte_end = self.tokens[token_end.saturating_sub(1)].byte_end;
+        Span {
+            byte_start,
+            byte_end,
+            token_start,
+            token_end,
+        }
     }
 
     // ── Entry point ─────────────────────────────────────────────────────
 
-    pub fn parse_entire_expression(&mut self) -> Result<AstNode, ParseError> {
+    pub fn parse_entire_expression(&mut self) -> Result<Expr, ParseError> {
         let expr = self.parse_expression()?;
         if self.peek() != TokenKind::Eof {
             let tok = self.current();
             return Err(ParseError::UnexpectedTokenAfterExpr {
                 found: tok.kind,
                 found_text: tok.text.clone(),
-                span: Span {
-                    byte_start: tok.byte_start,
-                    byte_end: tok.byte_end,
-                },
+                span: self.token_span(tok),
             });
         }
         Ok(expr)
@@ -96,121 +97,152 @@ impl<'a> Parser<'a> {
 
     // ── Expression precedence chain (lowest → highest) ──────────────────
 
-    fn parse_expression(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_expression(&mut self) -> Result<Expr, ParseError> {
         self.parse_implies()
     }
 
-    fn parse_implies(&mut self) -> Result<AstNode, ParseError> {
-        self.parse_binary_left("ImpliesExpression", &[TokenKind::Implies], Self::parse_or)
+    fn parse_implies(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_left(&[(TokenKind::Implies, BinOp::Implies)], Self::parse_or)
     }
 
-    fn parse_or(&mut self) -> Result<AstNode, ParseError> {
-        self.parse_binary_left("OrExpression", &[TokenKind::Or, TokenKind::Xor], Self::parse_and)
-    }
-
-    fn parse_and(&mut self) -> Result<AstNode, ParseError> {
-        self.parse_binary_left("AndExpression", &[TokenKind::And], Self::parse_membership)
-    }
-
-    fn parse_membership(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_or(&mut self) -> Result<Expr, ParseError> {
         self.parse_binary_left(
-            "MembershipExpression",
-            &[TokenKind::In, TokenKind::Contains],
+            &[(TokenKind::Or, BinOp::Or), (TokenKind::Xor, BinOp::Xor)],
+            Self::parse_and,
+        )
+    }
+
+    fn parse_and(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_left(&[(TokenKind::And, BinOp::And)], Self::parse_membership)
+    }
+
+    fn parse_membership(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_left(
+            &[
+                (TokenKind::In, BinOp::In),
+                (TokenKind::Contains, BinOp::Contains),
+            ],
             Self::parse_equality,
         )
     }
 
-    fn parse_equality(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_equality(&mut self) -> Result<Expr, ParseError> {
         self.parse_binary_left(
-            "EqualityExpression",
-            &[TokenKind::Eq, TokenKind::NotEq, TokenKind::Tilde, TokenKind::NotTilde],
+            &[
+                (TokenKind::Eq, BinOp::Eq),
+                (TokenKind::NotEq, BinOp::NotEq),
+                (TokenKind::Tilde, BinOp::EquivTilde),
+                (TokenKind::NotTilde, BinOp::NotEquivTilde),
+            ],
             Self::parse_type,
         )
     }
 
-    fn parse_type(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
+    fn parse_type(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
         let mut left = self.parse_inequality()?;
         while self.peek() == TokenKind::Is || self.peek() == TokenKind::As {
-            let op_tok = self.advance().clone();
+            let op = match self.peek() {
+                TokenKind::Is => TypeOp::Is,
+                TokenKind::As => TypeOp::As,
+                _ => unreachable!(),
+            };
+            self.advance();
             let type_spec = self.parse_type_specifier()?;
-            let mut node = AstNode::new("TypeExpression", start, self.tokens);
-            node.terminal_node_text.push(op_tok.text.clone());
-            node.children.push(left);
-            node.children.push(type_spec);
-            self.set_end(&mut node);
-            left = node;
+            let span = self.span_from(token_start);
+            left = Expr::Type {
+                lhs: Box::new(left),
+                op,
+                type_spec,
+                span,
+            };
         }
         Ok(left)
     }
 
-    fn parse_inequality(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_inequality(&mut self) -> Result<Expr, ParseError> {
         self.parse_binary_left(
-            "InequalityExpression",
-            &[TokenKind::Lt, TokenKind::Gt, TokenKind::LtEq, TokenKind::GtEq],
+            &[
+                (TokenKind::Lt, BinOp::Lt),
+                (TokenKind::Gt, BinOp::Gt),
+                (TokenKind::LtEq, BinOp::LtEq),
+                (TokenKind::GtEq, BinOp::GtEq),
+            ],
             Self::parse_union,
         )
     }
 
-    fn parse_union(&mut self) -> Result<AstNode, ParseError> {
-        self.parse_binary_left("UnionExpression", &[TokenKind::Pipe], Self::parse_additive)
+    fn parse_union(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_left(&[(TokenKind::Pipe, BinOp::Union)], Self::parse_additive)
     }
 
-    fn parse_additive(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_additive(&mut self) -> Result<Expr, ParseError> {
         self.parse_binary_left(
-            "AdditiveExpression",
-            &[TokenKind::Plus, TokenKind::Minus, TokenKind::Ampersand],
+            &[
+                (TokenKind::Plus, BinOp::Plus),
+                (TokenKind::Minus, BinOp::Minus),
+                (TokenKind::Ampersand, BinOp::Concat),
+            ],
             Self::parse_multiplicative,
         )
     }
 
-    fn parse_multiplicative(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_multiplicative(&mut self) -> Result<Expr, ParseError> {
         self.parse_binary_left(
-            "MultiplicativeExpression",
-            &[TokenKind::Star, TokenKind::Slash, TokenKind::Div, TokenKind::Mod],
+            &[
+                (TokenKind::Star, BinOp::Mul),
+                (TokenKind::Slash, BinOp::TrueDiv),
+                (TokenKind::Div, BinOp::IntDiv),
+                (TokenKind::Mod, BinOp::Mod),
+            ],
             Self::parse_unary,
         )
     }
 
-    fn parse_unary(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_unary(&mut self) -> Result<Expr, ParseError> {
         if self.peek() == TokenKind::Plus || self.peek() == TokenKind::Minus {
-            let start = self.pos;
-            let op_tok = self.advance().clone();
+            let token_start = self.pos;
+            let op = match self.peek() {
+                TokenKind::Plus => UnaryOp::Plus,
+                TokenKind::Minus => UnaryOp::Minus,
+                _ => unreachable!(),
+            };
+            self.advance();
             let operand = self.parse_unary()?;
-            let mut node = AstNode::new("PolarityExpression", start, self.tokens);
-            node.terminal_node_text.push(op_tok.text.clone());
-            node.children.push(operand);
-            self.set_end(&mut node);
-            Ok(node)
+            let span = self.span_from(token_start);
+            Ok(Expr::Polarity {
+                op,
+                operand: Box::new(operand),
+                span,
+            })
         } else {
             self.parse_postfix()
         }
     }
 
-    fn parse_postfix(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
+    fn parse_postfix(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
         let mut left = self.parse_term()?;
         loop {
             if self.peek() == TokenKind::Dot {
-                let dot = self.advance().clone();
-                let inv = self.parse_invocation()?;
-                let mut node = AstNode::new("InvocationExpression", start, self.tokens);
-                node.terminal_node_text.push(dot.text.clone());
-                node.children.push(left);
-                node.children.push(inv);
-                self.set_end(&mut node);
-                left = node;
+                self.advance();
+                let call = self.parse_invocation()?;
+                let span = self.span_from(token_start);
+                left = Expr::Invocation {
+                    receiver: Some(Box::new(left)),
+                    call,
+                    span,
+                };
             } else if self.peek() == TokenKind::LBracket {
-                let lb = self.advance().clone();
-                let index_expr = self.parse_expression()?;
-                let rb = self.expect(TokenKind::RBracket)?.clone();
-                let mut node = AstNode::new("IndexerExpression", start, self.tokens);
-                node.terminal_node_text.push(lb.text.clone());
-                node.terminal_node_text.push(rb.text.clone());
-                node.children.push(left);
-                node.children.push(index_expr);
-                self.set_end(&mut node);
-                left = node;
+                self.advance();
+                let index = self.parse_expression()?;
+                self.expect(TokenKind::RBracket)?;
+                let span = self.span_from(token_start);
+                left = Expr::Indexer {
+                    receiver: Box::new(left),
+                    index: Box::new(index),
+                    span,
+                };
             } else {
                 break;
             }
@@ -218,27 +250,24 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
-    fn parse_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let inner = self.parse_term_inner()?;
-        let mut term_expr = AstNode::new("TermExpression", start, self.tokens);
-        term_expr.children.push(inner);
-        self.set_end(&mut term_expr);
-        Ok(term_expr)
+    fn parse_term(&mut self) -> Result<Expr, ParseError> {
+        // The legacy AST wrapped every term in `TermExpression`. Lowering does
+        // that now; the parser just returns the inner Expr.
+        self.parse_term_inner()
     }
 
-    fn parse_term_inner(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_term_inner(&mut self) -> Result<Expr, ParseError> {
         match self.peek() {
             TokenKind::LParen => self.parse_parenthesized_term(),
             // ANTLR error recovery treats [expr] like (expr) in term position.
             // We replicate this so expressions like `intersect([list])` work.
             TokenKind::LBracket => self.parse_bracket_term(),
             TokenKind::LBrace => self.parse_null_literal_term(),
-            TokenKind::True | TokenKind::False => self.parse_simple_literal_term("BooleanLiteral"),
-            TokenKind::String => self.parse_simple_literal_term("StringLiteral"),
+            TokenKind::True | TokenKind::False => self.parse_boolean_literal_term(),
+            TokenKind::String => self.parse_string_literal_term(),
             TokenKind::Number => self.parse_number_or_quantity_literal_term(),
-            TokenKind::DateTime => self.parse_simple_literal_term("DateTimeLiteral"),
-            TokenKind::Time => self.parse_simple_literal_term("TimeLiteral"),
+            TokenKind::DateTime => self.parse_datetime_literal_term(),
+            TokenKind::Time => self.parse_time_literal_term(),
             TokenKind::Percent => self.parse_external_constant_term(),
             TokenKind::Identifier
             | TokenKind::DelimitedIdentifier
@@ -254,10 +283,7 @@ impl<'a> Parser<'a> {
                 Err(ParseError::UnexpectedTokenInTerm {
                     found: tok.kind,
                     found_text: tok.text.clone(),
-                    span: Span {
-                        byte_start: tok.byte_start,
-                        byte_end: tok.byte_end,
-                    },
+                    span: self.token_span(tok),
                 })
             }
         }
@@ -265,23 +291,23 @@ impl<'a> Parser<'a> {
 
     // ── Term variants ───────────────────────────────────────────────────
 
-    fn parse_parenthesized_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let lp = self.advance().clone();
-        let expr = self.parse_expression()?;
-        let rp = self.expect(TokenKind::RParen)?.clone();
-        let mut node = AstNode::new("ParenthesizedTerm", start, self.tokens);
-        node.terminal_node_text.push(lp.text.clone());
-        node.terminal_node_text.push(rp.text.clone());
-        node.children.push(expr);
-        self.set_end(&mut node);
-        Ok(node)
+    fn parse_parenthesized_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        self.advance(); // (
+        let inner = self.parse_expression()?;
+        self.expect(TokenKind::RParen)?;
+        let span = self.span_from(token_start);
+        Ok(Expr::Parenthesized {
+            inner: Box::new(inner),
+            span,
+        })
     }
 
     /// Handle `[expr]` in term position — ANTLR error recovery compatibility.
-    /// The brackets are dropped (they end up in the parent's terminalNodeText in ANTLR
-    /// but that's benign). The inner expression is returned directly.
-    fn parse_bracket_term(&mut self) -> Result<AstNode, ParseError> {
+    /// The brackets are dropped (they end up in the parent's terminalNodeText
+    /// in ANTLR but that's benign). The inner expression is returned directly,
+    /// without any wrapping.
+    fn parse_bracket_term(&mut self) -> Result<Expr, ParseError> {
         self.advance(); // skip '['
         let inner = self.parse_term_inner()?;
         if self.peek() == TokenKind::RBracket {
@@ -290,61 +316,62 @@ impl<'a> Parser<'a> {
         Ok(inner)
     }
 
-    fn parse_null_literal_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let lb = self.advance().clone();
-        let rb = self.expect(TokenKind::RBrace)?.clone();
-        let mut literal = AstNode::new("NullLiteral", start, self.tokens);
-        literal.terminal_node_text.push(lb.text.clone());
-        literal.terminal_node_text.push(rb.text.clone());
-        self.set_end(&mut literal);
-        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
-        term.children.push(literal);
-        self.set_end(&mut term);
-        Ok(term)
+    fn parse_null_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        self.advance(); // {
+        self.expect(TokenKind::RBrace)?;
+        let span = self.span_from(token_start);
+        Ok(Expr::Literal(Literal::Null { span }))
     }
 
-    fn parse_simple_literal_term(
-        &mut self,
-        literal_kind: &'static str,
-    ) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let tok = self.advance().clone();
-        let mut literal = AstNode::new(literal_kind, start, self.tokens);
-        literal.terminal_node_text.push(tok.text.clone());
-        self.set_end(&mut literal);
-        let mut term = AstNode::new("LiteralTerm", start, self.tokens);
-        term.children.push(literal);
-        self.set_end(&mut term);
-        Ok(term)
+    fn parse_boolean_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let value = self.peek() == TokenKind::True;
+        self.advance();
+        let span = self.span_from(token_start);
+        Ok(Expr::Literal(Literal::Boolean { value, span }))
     }
 
-    fn parse_number_or_quantity_literal_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let num_tok = self.advance().clone();
+    fn parse_string_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let raw = self.advance().text.clone();
+        let span = self.span_from(token_start);
+        Ok(Expr::Literal(Literal::String { raw, span }))
+    }
+
+    fn parse_datetime_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let raw = self.advance().text.clone();
+        let span = self.span_from(token_start);
+        Ok(Expr::Literal(Literal::DateTime { raw, span }))
+    }
+
+    fn parse_time_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let raw = self.advance().text.clone();
+        let span = self.span_from(token_start);
+        Ok(Expr::Literal(Literal::Time { raw, span }))
+    }
+
+    fn parse_number_or_quantity_literal_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let number_text = self.advance().text.clone();
 
         // Check if next token is a unit (string literal or datetime precision word)
         if self.is_unit_start() {
-            let unit_node = self.parse_unit()?;
-            let mut quantity = AstNode::new("Quantity", start, self.tokens);
-            quantity.terminal_node_text.push(num_tok.text.clone());
-            quantity.children.push(unit_node);
-            self.set_end(&mut quantity);
-            let mut ql = AstNode::new("QuantityLiteral", start, self.tokens);
-            ql.children.push(quantity);
-            self.set_end(&mut ql);
-            let mut term = AstNode::new("LiteralTerm", start, self.tokens);
-            term.children.push(ql);
-            self.set_end(&mut term);
-            Ok(term)
+            let unit = self.parse_unit()?;
+            let span = self.span_from(token_start);
+            Ok(Expr::Literal(Literal::Quantity {
+                number: number_text,
+                unit,
+                span,
+            }))
         } else {
-            let mut literal = AstNode::new("NumberLiteral", start, self.tokens);
-            literal.terminal_node_text.push(num_tok.text.clone());
-            self.set_end(&mut literal);
-            let mut term = AstNode::new("LiteralTerm", start, self.tokens);
-            term.children.push(literal);
-            self.set_end(&mut term);
-            Ok(term)
+            let span = self.span_from(token_start);
+            Ok(Expr::Literal(Literal::Number {
+                raw: number_text,
+                span,
+            }))
         }
     }
 
@@ -359,114 +386,94 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_unit(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let mut unit = AstNode::new("Unit", start, self.tokens);
+    fn parse_unit(&mut self) -> Result<Unit, ParseError> {
+        let token_start = self.pos;
         match self.peek() {
             TokenKind::String => {
-                let tok = self.advance().clone();
-                unit.terminal_node_text.push(tok.text.clone());
+                let raw = self.advance().text.clone();
+                let span = self.span_from(token_start);
+                Ok(Unit::String { raw, span })
             }
             TokenKind::Identifier => {
                 let text = self.current().text.clone();
                 if is_datetime_precision(&text) {
-                    let tok = self.advance().clone();
-                    let mut dtp = AstNode::new("DateTimePrecision", start, self.tokens);
-                    dtp.terminal_node_text.push(tok.text.clone());
-                    self.set_end(&mut dtp);
-                    unit.children.push(dtp);
+                    self.advance();
+                    let span = self.span_from(token_start);
+                    Ok(Unit::DateTimePrecision { word: text, span })
                 } else if is_plural_datetime_precision(&text) {
-                    let tok = self.advance().clone();
-                    let mut pdtp = AstNode::new("PluralDateTimePrecision", start, self.tokens);
-                    pdtp.terminal_node_text.push(tok.text.clone());
-                    self.set_end(&mut pdtp);
-                    unit.children.push(pdtp);
+                    self.advance();
+                    let span = self.span_from(token_start);
+                    Ok(Unit::PluralDateTimePrecision { word: text, span })
                 } else {
                     let tok = self.current();
-                    return Err(ParseError::ExpectedUnit {
+                    Err(ParseError::ExpectedUnit {
                         found_text: Some(text),
-                        span: Span {
-                            byte_start: tok.byte_start,
-                            byte_end: tok.byte_end,
-                        },
-                    });
+                        span: self.token_span(tok),
+                    })
                 }
             }
             _ => {
                 let tok = self.current();
-                return Err(ParseError::ExpectedUnit {
+                Err(ParseError::ExpectedUnit {
                     found_text: None,
-                    span: Span {
-                        byte_start: tok.byte_start,
-                        byte_end: tok.byte_end,
-                    },
-                });
+                    span: self.token_span(tok),
+                })
             }
         }
-        self.set_end(&mut unit);
-        Ok(unit)
     }
 
-    fn parse_external_constant_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let pct = self.advance().clone();
-        // After %, expect identifier or string
-        let child = match self.peek() {
+    fn parse_external_constant_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        self.advance(); // %
+        // After %, expect identifier or string. The string-form uses the
+        // string token's span (NOT the leading %); this matches the ANTLR
+        // off-by-one where the inner Identifier's token_start sits AFTER the
+        // `%` token.
+        let ident = match self.peek() {
             TokenKind::String => {
-                let tok = self.advance().clone();
-                let mut id = AstNode::new("Identifier", start + 1, self.tokens);
-                id.terminal_node_text.push(tok.text.clone());
-                self.set_end(&mut id);
-                id
+                let str_token_start = self.pos;
+                let raw = self.advance().text.clone();
+                let span = self.span_from(str_token_start);
+                ExternalConstantId::String { raw, span }
             }
-            _ => self.parse_identifier()?,
+            _ => ExternalConstantId::Identifier(self.parse_identifier()?),
         };
-        let mut ext = AstNode::new("ExternalConstant", start, self.tokens);
-        ext.terminal_node_text.push(pct.text.clone());
-        ext.children.push(child);
-        self.set_end(&mut ext);
-        let mut term = AstNode::new("ExternalConstantTerm", start, self.tokens);
-        term.children.push(ext);
-        self.set_end(&mut term);
-        Ok(term)
+        let span = self.span_from(token_start);
+        Ok(Expr::ExternalConstant { ident, span })
     }
 
-    fn parse_invocation_term(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let inv = self.parse_invocation()?;
-        let mut term = AstNode::new("InvocationTerm", start, self.tokens);
-        term.children.push(inv);
-        self.set_end(&mut term);
-        Ok(term)
+    fn parse_invocation_term(&mut self) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
+        let call = self.parse_invocation()?;
+        let span = self.span_from(token_start);
+        Ok(Expr::Invocation {
+            receiver: None,
+            call,
+            span,
+        })
     }
 
     // ── Invocation ──────────────────────────────────────────────────────
 
-    fn parse_invocation(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_invocation(&mut self) -> Result<Invocation, ParseError> {
         match self.peek() {
             TokenKind::DollarThis => {
-                let start = self.pos;
-                let tok = self.advance().clone();
-                let mut node = AstNode::new("ThisInvocation", start, self.tokens);
-                node.terminal_node_text.push(tok.text.clone());
-                self.set_end(&mut node);
-                Ok(node)
+                let token_start = self.pos;
+                self.advance();
+                let span = self.span_from(token_start);
+                Ok(Invocation::This { span })
             }
             TokenKind::DollarIndex => {
-                let start = self.pos;
-                let tok = self.advance().clone();
-                let mut node = AstNode::new("IndexInvocation", start, self.tokens);
-                node.terminal_node_text.push(tok.text.clone());
-                self.set_end(&mut node);
-                Ok(node)
+                let token_start = self.pos;
+                self.advance();
+                let span = self.span_from(token_start);
+                Ok(Invocation::Index { span })
             }
             TokenKind::DollarTotal => {
-                let start = self.pos;
-                let tok = self.advance().clone();
-                let mut node = AstNode::new("TotalInvocation", start, self.tokens);
-                node.terminal_node_text.push(tok.text.clone());
-                self.set_end(&mut node);
-                Ok(node)
+                let token_start = self.pos;
+                self.advance();
+                let span = self.span_from(token_start);
+                Ok(Invocation::Total { span })
             }
             TokenKind::Identifier
             | TokenKind::DelimitedIdentifier
@@ -474,16 +481,12 @@ impl<'a> Parser<'a> {
             | TokenKind::Is
             | TokenKind::Contains
             | TokenKind::In => {
-                // Lookahead: identifier followed by '(' → function invocation
-                let start = self.pos;
+                let token_start = self.pos;
                 let ident = self.parse_identifier()?;
                 if self.peek() == TokenKind::LParen {
-                    self.parse_function_invocation(start, ident)
+                    self.parse_function_invocation(token_start, ident)
                 } else {
-                    let mut node = AstNode::new("MemberInvocation", start, self.tokens);
-                    node.children.push(ident);
-                    self.set_end(&mut node);
-                    Ok(node)
+                    Ok(Invocation::Member { ident })
                 }
             }
             _ => {
@@ -491,10 +494,7 @@ impl<'a> Parser<'a> {
                 Err(ParseError::ExpectedInvocation {
                     found: tok.kind,
                     found_text: tok.text.clone(),
-                    span: Span {
-                        byte_start: tok.byte_start,
-                        byte_end: tok.byte_end,
-                    },
+                    span: self.token_span(tok),
                 })
             }
         }
@@ -502,44 +502,26 @@ impl<'a> Parser<'a> {
 
     fn parse_function_invocation(
         &mut self,
-        start: usize,
-        ident: AstNode,
-    ) -> Result<AstNode, ParseError> {
-        let lp = self.advance().clone();
-        let mut functn = AstNode::new("Functn", start, self.tokens);
-        functn.terminal_node_text.push(lp.text.clone());
-        functn.children.push(ident);
+        token_start: usize,
+        name: Identifier,
+    ) -> Result<Invocation, ParseError> {
+        self.advance(); // (
+        let mut args: Vec<Expr> = Vec::new();
         if self.peek() != TokenKind::RParen {
-            let params = self.parse_param_list()?;
-            functn.children.push(params);
+            args.push(self.parse_expression()?);
+            while self.peek() == TokenKind::Comma {
+                self.advance();
+                args.push(self.parse_expression()?);
+            }
         }
-        let rp = self.expect(TokenKind::RParen)?.clone();
-        functn.terminal_node_text.push(rp.text.clone());
-        self.set_end(&mut functn);
-        let mut fi = AstNode::new("FunctionInvocation", start, self.tokens);
-        fi.children.push(functn);
-        self.set_end(&mut fi);
-        Ok(fi)
-    }
-
-    fn parse_param_list(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let mut pl = AstNode::new("ParamList", start, self.tokens);
-        let first = self.parse_expression()?;
-        pl.children.push(first);
-        while self.peek() == TokenKind::Comma {
-            let comma = self.advance().clone();
-            pl.terminal_node_text.push(comma.text.clone());
-            let next = self.parse_expression()?;
-            pl.children.push(next);
-        }
-        self.set_end(&mut pl);
-        Ok(pl)
+        self.expect(TokenKind::RParen)?;
+        let span = self.span_from(token_start);
+        Ok(Invocation::Function { name, args, span })
     }
 
     // ── Identifier ──────────────────────────────────────────────────────
 
-    fn parse_identifier(&mut self) -> Result<AstNode, ParseError> {
+    fn parse_identifier(&mut self) -> Result<Identifier, ParseError> {
         match self.peek() {
             TokenKind::Identifier
             | TokenKind::DelimitedIdentifier
@@ -547,22 +529,17 @@ impl<'a> Parser<'a> {
             | TokenKind::Is
             | TokenKind::Contains
             | TokenKind::In => {
-                let start = self.pos;
-                let tok = self.advance().clone();
-                let mut node = AstNode::new("Identifier", start, self.tokens);
-                node.terminal_node_text.push(tok.text.clone());
-                self.set_end(&mut node);
-                Ok(node)
+                let token_start = self.pos;
+                let raw = self.advance().text.clone();
+                let span = self.span_from(token_start);
+                Ok(Identifier { raw, span })
             }
             _ => {
                 let tok = self.current();
                 Err(ParseError::ExpectedIdentifier {
                     found: tok.kind,
                     found_text: tok.text.clone(),
-                    span: Span {
-                        byte_start: tok.byte_start,
-                        byte_end: tok.byte_end,
-                    },
+                    span: self.token_span(tok),
                 })
             }
         }
@@ -570,49 +547,48 @@ impl<'a> Parser<'a> {
 
     // ── TypeSpecifier ───────────────────────────────────────────────────
 
-    fn parse_type_specifier(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let qi = self.parse_qualified_identifier()?;
-        let mut ts = AstNode::new("TypeSpecifier", start, self.tokens);
-        ts.children.push(qi);
-        self.set_end(&mut ts);
-        Ok(ts)
+    fn parse_type_specifier(&mut self) -> Result<TypeSpecifier, ParseError> {
+        let token_start = self.pos;
+        let qualified = self.parse_qualified_identifier()?;
+        let span = self.span_from(token_start);
+        Ok(TypeSpecifier { qualified, span })
     }
 
-    fn parse_qualified_identifier(&mut self) -> Result<AstNode, ParseError> {
-        let start = self.pos;
-        let mut qi = AstNode::new("QualifiedIdentifier", start, self.tokens);
-        let first = self.parse_identifier()?;
-        qi.children.push(first);
+    fn parse_qualified_identifier(&mut self) -> Result<QualifiedIdentifier, ParseError> {
+        let token_start = self.pos;
+        let mut parts = Vec::new();
+        parts.push(self.parse_identifier()?);
         while self.peek() == TokenKind::Dot {
-            let dot = self.advance().clone();
-            qi.terminal_node_text.push(dot.text.clone());
-            let next = self.parse_identifier()?;
-            qi.children.push(next);
+            self.advance();
+            parts.push(self.parse_identifier()?);
         }
-        self.set_end(&mut qi);
-        Ok(qi)
+        let span = self.span_from(token_start);
+        Ok(QualifiedIdentifier { parts, span })
     }
 
     // ── DRY binary left-associative helper ──────────────────────────────
 
     fn parse_binary_left(
         &mut self,
-        node_type: &'static str,
-        ops: &[TokenKind],
-        next: fn(&mut Self) -> Result<AstNode, ParseError>,
-    ) -> Result<AstNode, ParseError> {
-        let start = self.pos;
+        ops: &[(TokenKind, BinOp)],
+        next: fn(&mut Self) -> Result<Expr, ParseError>,
+    ) -> Result<Expr, ParseError> {
+        let token_start = self.pos;
         let mut left = next(self)?;
-        while ops.contains(&self.peek()) {
-            let op_tok = self.advance().clone();
+        loop {
+            let op = match ops.iter().find(|(k, _)| *k == self.peek()) {
+                Some((_, op)) => *op,
+                None => break,
+            };
+            self.advance();
             let right = next(self)?;
-            let mut node = AstNode::new(node_type, start, self.tokens);
-            node.terminal_node_text.push(op_tok.text.clone());
-            node.children.push(left);
-            node.children.push(right);
-            self.set_end(&mut node);
-            left = node;
+            let span = self.span_from(token_start);
+            left = Expr::Binary {
+                op,
+                lhs: Box::new(left),
+                rhs: Box::new(right),
+                span,
+            };
         }
         Ok(left)
     }
@@ -631,3 +607,4 @@ fn is_plural_datetime_precision(s: &str) -> bool {
         "years" | "months" | "weeks" | "days" | "hours" | "minutes" | "seconds" | "milliseconds"
     )
 }
+

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -4,7 +4,7 @@
 /// reference in `expr` with the parsed `base` AST, then serializes the
 /// result back to a valid FHIRPath string.
 
-use crate::parser::AstNode;
+use crate::compat::AstNode;
 use crate::ParseError;
 
 // ── Public API ─────────────────────────────────────────────────────────
@@ -15,8 +15,8 @@ use crate::ParseError;
 /// serialized result.  Returns `expr` unchanged when no `%context` reference
 /// exists.
 pub fn resolve_context(expr: &str, base: &str) -> Result<String, ParseError> {
-    let expr_ast = crate::parse(expr)?;
-    let base_ast = crate::parse(base)?;
+    let (expr_ast, _) = crate::parse_with_compat(expr)?;
+    let (base_ast, _) = crate::parse_with_compat(base)?;
     let resolved = resolve_context_ast(&expr_ast, &base_ast);
     Ok(ast_to_string(&resolved))
 }
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
 
     fn roundtrip(expr: &str) -> String {
-        let ast = crate::parse(expr).unwrap();
+        let (ast, _) = crate::parse_with_compat(expr).unwrap();
         ast_to_string(&ast)
     }
 


### PR DESCRIPTION
## Summary

The central refactor of the FHIRPath parser. Parser internals now produce the typed `Expr` enum from `src/ast.rs`. A new lowering layer reproduces the legacy ANTLR-shaped `AstNode` tree byte-for-byte for the Python/WASM bindings and the existing `analyze` / `resolve` consumers (Phase 4 will migrate those to consume `Expr` directly).

## What's in this PR

- **\`src/parser.rs\` rewritten** — same recursive-descent skeleton, same precedence chain. Every \`parse_*\` builder now returns the appropriate typed value (\`Expr\`, \`Invocation\`, \`Identifier\`, \`TypeSpecifier\`, etc.) instead of \`AstNode\`. \`parse_binary_left\` is parameterized on \`BinOp\`.
- **\`AstNode\` moved to \`src/compat.rs\`.** It's now a lowering output, not a parser product.
- **\`Span\` gains \`token_start\`/\`token_end\`** fields so the lowering layer can populate \`AstNode.token_start\`/\`token_end\` and keep \`compute_text\` byte-faithful.
- **\`compat::lower(&Expr, &[Token]) -> AstNode\`** — new function. Walks the typed tree and reconstructs the ANTLR shape exactly: re-emits wrapper nodes (\`TermExpression\`, \`LiteralTerm\`, \`InvocationTerm\`, \`ExternalConstantTerm\`), populates \`terminal_node_text\` from operator keywords (\`BinOp::keyword\`, \`UnaryOp::keyword\`, \`TypeOp::keyword\`) and hardcoded delimiters, preserves the \`%\`-token off-by-one for \`%'string'\` external constants, omits \`ParamList\` for zero-arg function calls.
- **\`lib.rs::parse(expr) -> Result<Expr, ParseError>\`** is the new primary API. **\`parse_with_compat(expr) -> Result<(AstNode, Vec<Token>), ParseError>\`** is the back-compat path, used by the bindings and the consumers that haven't migrated yet.
- **Consumers wired up**: \`resolve.rs\`, \`bindings/{python,wasm}.rs\`, and \`analyze/{annotations,completions,validate_link_ids,result_type}.rs\` call \`parse_with_compat\` (or lower inline when they already have tokens). No consumer logic changed — only how they obtain the \`AstNode\`.

## Verification

- [x] \`cargo test --no-default-features\` — **184 passed, 0 failed** (182 prior + 2 snapshot tests covering 91 golden + 66 synthetic expressions)
- [x] \`cargo check --no-default-features --features wasm\` — clean
- [x] **All 157 snapshot expressions match the legacy parser's output byte-for-byte on first try** — the lowering layer is correct.

## What's next

- **Phase 4** — migrate \`analyze/*.rs\` and \`resolve.rs\` to consume \`Expr\` directly (drop \`AstNode\` matching). Reviewable file-by-file since the typed \`Expr\` and the lowered \`AstNode\` coexist.
- **Phase 5** — collapse the duplicated \`compat::lower_to_compat_json\` and \`bindings/python.rs::ast_to_pydict\`. Either via a JSON walker or by adding \`pythonize\`.
- **Phase 6** — delete the lowering layer once all internal consumers use \`Expr\`. \`AstNode\` survives only as the bindings' serialization shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)