### PR TITLE
refactor(analyze, resolve): consume typed Expr directly (Phase 4)

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -990,7 +990,7 @@ pub(crate) fn annotate_expression_with_diagnostics(
 /// (notably `result_type::infer_result_type`) instead of reparsing.
 pub(crate) fn annotate_expression_with_ast(
     expr: &str,
-) -> Result<(AstNode, Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
+) -> Result<(crate::ast::Expr, Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
     let tokens = crate::lexer::tokenize(expr)?;
     let mut p = crate::parser::Parser::new(&tokens);
     let typed = p.parse_entire_expression()?;
@@ -1005,7 +1005,7 @@ pub(crate) fn annotate_expression_with_ast(
 
     let mut all: Vec<Annotation> = answer_refs.into_iter().chain(coded_values).collect();
     all.sort_by_key(|a| a.span.start);
-    Ok((root, all, diagnostics))
+    Ok((typed, all, diagnostics))
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -4,7 +4,7 @@
 /// (e.g. `item.where(linkId='x').answer.value.code`).
 /// Pass 2 identifies coded values in equality/equivalence comparisons against those references.
 
-use crate::compat::AstNode;
+use crate::ast::{BinOp, Expr, ExternalConstantId, Invocation, Literal};
 
 use super::{Annotation, AnnotationKind, Attribution, Diagnostic, DiagnosticCode, Severity, Span, ValueAccessor};
 
@@ -50,207 +50,174 @@ pub(crate) struct ChainStep {
 
 // ── Helper functions ────────────────────────────────────────────────────
 
-/// If `node` is an Identifier, return its name.
-pub(crate) fn get_identifier_name(node: &AstNode) -> Option<&str> {
-    if node.node_type == "Identifier" {
-        node.terminal_node_text.first().map(|s| s.as_str())
+/// Extract the bare value of a string literal — strips the surrounding
+/// single quotes that `Literal::String::raw` keeps.
+fn extract_string_value(expr: &Expr) -> Option<String> {
+    let expr = unwrap_parens(expr);
+    match expr {
+        Expr::Literal(Literal::String { raw, .. }) if raw.len() >= 2 => {
+            Some(raw[1..raw.len() - 1].to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Find a String literal Expr by descending into parens.
+fn find_string_literal(expr: &Expr) -> Option<&Expr> {
+    let inner = unwrap_parens(expr);
+    if matches!(inner, Expr::Literal(Literal::String { .. })) {
+        Some(inner)
     } else {
         None
     }
 }
 
-/// Navigate through TermExpression -> LiteralTerm -> StringLiteral to extract the string value.
-/// Strips the surrounding quote characters.
-fn extract_string_value(node: &AstNode) -> Option<String> {
-    let mut current = node;
-
-    // Walk through TermExpression -> LiteralTerm -> StringLiteral
-    if current.node_type == "TermExpression" {
-        current = current.children.first()?;
+/// Peel `Expr::Parenthesized` wrappers.
+fn unwrap_parens(mut expr: &Expr) -> &Expr {
+    while let Expr::Parenthesized { inner, .. } = expr {
+        expr = inner;
     }
-    if current.node_type == "LiteralTerm" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "StringLiteral" {
-        let raw = current.terminal_node_text.first()?;
-        if raw.len() >= 2 {
-            return Some(raw[1..raw.len() - 1].to_string());
-        }
-    }
-    None
+    expr
 }
 
-/// Extract a linkId from a `where(linkId='...')` call.
-/// `functn` is the `Functn` node inside a `FunctionInvocation`.
-/// Returns the linkId string value and the byte span of the string literal.
-pub(crate) fn extract_link_id_from_where(functn: &AstNode) -> Option<(String, Span)> {
-    // Functn.children: [Identifier("where"), ParamList]
-    let name_node = functn.children.first()?;
-    if get_identifier_name(name_node)? != "where" {
+/// Convert an `Expr` span into the analyze-layer `Span`.
+fn span_of(expr: &Expr) -> Span {
+    let s = expr.span();
+    Span {
+        start: s.byte_start,
+        end: s.byte_end,
+    }
+}
+
+/// Walk `(receiver?).<member>` returning the member identifier name when the
+/// receiver is `$this` (or absent). Used to recognize either `linkId` or
+/// `$this.linkId` as the LHS of a where-predicate.
+fn extract_member_identifier_name(expr: &Expr) -> Option<&str> {
+    let expr = unwrap_parens(expr);
+    match expr {
+        // Bare member: `linkId`
+        Expr::Invocation {
+            receiver: None,
+            call: Invocation::Member { ident },
+            ..
+        } => Some(ident.raw.as_str()),
+        // `$this.linkId`
+        Expr::Invocation {
+            receiver: Some(rcv),
+            call: Invocation::Member { ident },
+            ..
+        } => match unwrap_parens(rcv) {
+            Expr::Invocation {
+                receiver: None,
+                call: Invocation::This { .. },
+                ..
+            } => Some(ident.raw.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Extract a linkId from a `where(linkId='...')` call. Returns the linkId
+/// value and the byte span of the string literal.
+pub(crate) fn extract_link_id_from_where(args: &[Expr]) -> Option<(String, Span)> {
+    let arg = unwrap_parens(args.first()?);
+    let Expr::Binary { op, lhs, rhs, .. } = arg else {
+        return None;
+    };
+    if !matches!(op, BinOp::Eq) {
         return None;
     }
-
-    let param_list = functn.children.get(1)?;
-    if param_list.node_type != "ParamList" {
-        return None;
-    }
-
-    let equality = param_list.children.first()?;
-    if equality.node_type != "EqualityExpression" {
-        return None;
-    }
-
-    // EqualityExpression.children: [left, right]
-    let left = equality.children.first()?;
-    let right = equality.children.get(1)?;
-
-    // left should be TermExpression -> InvocationTerm -> MemberInvocation -> Identifier("linkId")
-    let left_name = extract_member_identifier_name(left)?;
+    let left_name = extract_member_identifier_name(lhs)?;
     if left_name != "linkId" {
         return None;
     }
-
-    // Navigate to the StringLiteral node to get its byte span
-    let string_node = find_string_literal_node(right)?;
-    let value = extract_string_value(right)?;
-    Some((value, Span { start: string_node.byte_start, end: string_node.byte_end }))
+    let string_node = find_string_literal(rhs)?;
+    let value = extract_string_value(rhs)?;
+    Some((value, span_of(string_node)))
 }
 
-/// Navigate through TermExpression -> LiteralTerm -> StringLiteral to find the StringLiteral node.
-fn find_string_literal_node(node: &AstNode) -> Option<&AstNode> {
-    let mut current = node;
-    if current.node_type == "TermExpression" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "LiteralTerm" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "StringLiteral" {
-        Some(current)
-    } else {
-        None
-    }
-}
-
-/// Navigate TermExpression -> InvocationTerm -> MemberInvocation -> Identifier to get the name.
-///
-/// Also accepts `$this.<ident>` — an InvocationExpression whose receiver is
-/// `$this` and whose member names `<ident>`.
-fn extract_member_identifier_name(node: &AstNode) -> Option<&str> {
-    if node.node_type == "InvocationExpression" {
-        let receiver = node.children.first()?;
-        let member = node.children.get(1)?;
-        if !is_this_invocation(receiver) {
-            return None;
-        }
-        if member.node_type != "MemberInvocation" {
-            return None;
-        }
-        return get_identifier_name(member.children.first()?);
-    }
-
-    let mut current = node;
-    if current.node_type == "TermExpression" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "InvocationTerm" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "MemberInvocation" {
-        current = current.children.first()?;
-    }
-    get_identifier_name(current)
-}
-
-/// Returns true if `node` is a `TermExpression -> InvocationTerm -> ThisInvocation`.
-fn is_this_invocation(node: &AstNode) -> bool {
-    let mut current = node;
-    if current.node_type == "TermExpression" {
-        match current.children.first() {
-            Some(c) => current = c,
-            None => return false,
-        }
-    }
-    if current.node_type == "InvocationTerm" {
-        match current.children.first() {
-            Some(c) => current = c,
-            None => return false,
-        }
-    }
-    current.node_type == "ThisInvocation"
-}
-
-/// Recursively flatten an InvocationExpression tree into a chain of steps.
-pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
-    match node.node_type {
-        "TermExpression" => {
-            let inner = node.children.first()?;
-            match inner.node_type {
-                "InvocationTerm" => {
-                    let member = inner.children.first()?;
-                    match member.node_type {
-                        "MemberInvocation" => {
-                            let ident = member.children.first()?;
-                            let name = get_identifier_name(ident)?.to_string();
-                            Some(vec![ChainStep {
-                                kind: ChainStepKind::Identifier(name),
-                                link_id_span: None,
-                            }])
-                        }
-                        "ThisInvocation" => Some(vec![ChainStep {
-                            kind: ChainStepKind::ContextVar(ContextVarName::This),
-                            link_id_span: None,
-                        }]),
-                        "IndexInvocation" => Some(vec![ChainStep {
-                            kind: ChainStepKind::ContextVar(ContextVarName::Index),
-                            link_id_span: None,
-                        }]),
-                        "TotalInvocation" => Some(vec![ChainStep {
-                            kind: ChainStepKind::ContextVar(ContextVarName::Total),
-                            link_id_span: None,
-                        }]),
-                        _ => None,
+/// Recursively flatten an InvocationExpression / IndexerExpression tree into
+/// a chain of steps.
+pub(crate) fn decompose_chain(expr: &Expr) -> Option<Vec<ChainStep>> {
+    let expr = unwrap_parens(expr);
+    match expr {
+        Expr::Invocation {
+            receiver: None,
+            call,
+            ..
+        } => match call {
+            Invocation::Member { ident } => Some(vec![ChainStep {
+                kind: ChainStepKind::Identifier(ident.raw.clone()),
+                link_id_span: None,
+            }]),
+            Invocation::This { .. } => Some(vec![ChainStep {
+                kind: ChainStepKind::ContextVar(ContextVarName::This),
+                link_id_span: None,
+            }]),
+            Invocation::Index { .. } => Some(vec![ChainStep {
+                kind: ChainStepKind::ContextVar(ContextVarName::Index),
+                link_id_span: None,
+            }]),
+            Invocation::Total { .. } => Some(vec![ChainStep {
+                kind: ChainStepKind::ContextVar(ContextVarName::Total),
+                link_id_span: None,
+            }]),
+            Invocation::Function { name, args, .. } => {
+                let func_name = name.raw.clone();
+                let (link_id, link_id_span) = if func_name == "where" {
+                    match extract_link_id_from_where(args) {
+                        Some((id, span)) => (Some(id), Some(span)),
+                        None => (None, None),
                     }
-                }
-                "ExternalConstantTerm" => {
-                    let ext_const = inner.children.first()?;
-                    if ext_const.node_type != "ExternalConstant" {
-                        return None;
-                    }
-                    let ident = ext_const.children.first()?;
-                    let name = get_identifier_name(ident)?.to_string();
-                    Some(vec![ChainStep {
-                        kind: ChainStepKind::External(name),
-                        link_id_span: None,
-                    }])
-                }
-                _ => None,
+                } else {
+                    (None, None)
+                };
+                let integer_arg = if func_name == "skip" || func_name == "take" {
+                    args.first().and_then(extract_integer_literal)
+                } else {
+                    None
+                };
+                Some(vec![ChainStep {
+                    kind: ChainStepKind::Function {
+                        name: func_name,
+                        link_id,
+                        integer_arg,
+                    },
+                    link_id_span,
+                }])
             }
+        },
+        Expr::ExternalConstant { ident, .. } => {
+            let name = match ident {
+                ExternalConstantId::Identifier(id) => id.raw.clone(),
+                ExternalConstantId::String { raw, .. } if raw.len() >= 2 => {
+                    raw[1..raw.len() - 1].to_string()
+                }
+                ExternalConstantId::String { raw, .. } => raw.clone(),
+            };
+            Some(vec![ChainStep {
+                kind: ChainStepKind::External(name),
+                link_id_span: None,
+            }])
         }
-        "InvocationExpression" => {
-            let receiver = node.children.first()?;
-            let member = node.children.get(1)?;
-
-            let mut steps = decompose_chain(receiver)?;
-
-            match member.node_type {
-                "MemberInvocation" => {
-                    let ident = member.children.first()?;
-                    let name = get_identifier_name(ident)?.to_string();
+        Expr::Invocation {
+            receiver: Some(rcv),
+            call,
+            ..
+        } => {
+            let mut steps = decompose_chain(rcv)?;
+            match call {
+                Invocation::Member { ident } => {
                     steps.push(ChainStep {
-                        kind: ChainStepKind::Identifier(name),
+                        kind: ChainStepKind::Identifier(ident.raw.clone()),
                         link_id_span: None,
                     });
                 }
-                "FunctionInvocation" => {
-                    let functn = member.children.first()?;
-                    if functn.node_type != "Functn" {
-                        return None;
-                    }
-                    let func_ident = functn.children.first()?;
-                    let func_name = get_identifier_name(func_ident)?.to_string();
+                Invocation::Function { name, args, .. } => {
+                    let func_name = name.raw.clone();
                     let (link_id, link_id_span) = if func_name == "where" {
-                        match extract_link_id_from_where(functn) {
+                        match extract_link_id_from_where(args) {
                             Some((id, span)) => (Some(id), Some(span)),
                             None => (None, None),
                         }
@@ -258,7 +225,7 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                         (None, None)
                     };
                     let integer_arg = if func_name == "skip" || func_name == "take" {
-                        extract_first_integer_arg(functn)
+                        args.first().and_then(extract_integer_literal)
                     } else {
                         None
                     };
@@ -271,18 +238,16 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
                         link_id_span,
                     });
                 }
+                // $this/$index/$total etc. shouldn't appear in chained position
                 _ => return None,
             }
-
             Some(steps)
         }
-        "IndexerExpression" => {
-            let receiver = node.children.first()?;
-            let index_expr = node.children.get(1)?;
+        Expr::Indexer { receiver, index, .. } => {
             let mut steps = decompose_chain(receiver)?;
             steps.push(ChainStep {
                 kind: ChainStepKind::Indexer {
-                    index: extract_integer_literal(index_expr),
+                    index: extract_integer_literal(index),
                 },
                 link_id_span: None,
             });
@@ -292,30 +257,12 @@ pub(crate) fn decompose_chain(node: &AstNode) -> Option<Vec<ChainStep>> {
     }
 }
 
-/// If the `Functn` node has a first argument that is an integer literal, return it.
-fn extract_first_integer_arg(functn: &AstNode) -> Option<i64> {
-    let param_list = functn.children.get(1)?;
-    if param_list.node_type != "ParamList" {
-        return None;
+/// Pull an integer value out of an Expr literal (peeling parens).
+fn extract_integer_literal(expr: &Expr) -> Option<i64> {
+    match unwrap_parens(expr) {
+        Expr::Literal(Literal::Number { raw, .. }) => raw.parse::<i64>().ok(),
+        _ => None,
     }
-    let arg = param_list.children.first()?;
-    extract_integer_literal(arg)
-}
-
-/// Walk TermExpression -> LiteralTerm -> NumberLiteral and parse its text as an integer.
-fn extract_integer_literal(node: &AstNode) -> Option<i64> {
-    let mut current = node;
-    if current.node_type == "TermExpression" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "LiteralTerm" {
-        current = current.children.first()?;
-    }
-    if current.node_type == "NumberLiteral" {
-        let raw = current.terminal_node_text.first()?;
-        return raw.parse::<i64>().ok();
-    }
-    None
 }
 
 // ── QR selection state lattice ──────────────────────────────────────────
@@ -730,22 +677,25 @@ fn match_qr_path(steps: &[ChainStep]) -> MatchOutcome {
     }
 }
 
-// ── AST walkers ─────────────────────────────────────────────────────────
+// ── Expr walkers ────────────────────────────────────────────────────────
+
+/// Whether this Expr is a chain head/segment we should try to decompose.
+fn is_chain_node(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Invocation { .. } | Expr::Indexer { .. } | Expr::ExternalConstant { .. }
+    )
+}
 
 /// Pass 1: Find answer and item references by DFS over the AST.
 /// Also emits `ExpressionNotAttributable` diagnostics for chains that entered
 /// QR territory but degraded.
-fn find_answer_refs(node: &AstNode, out: &mut Vec<Annotation>, diagnostics: &mut Vec<Diagnostic>) {
-    // Try to match this node as a QR navigation chain
-    if matches!(
-        node.node_type,
-        "InvocationExpression" | "TermExpression" | "IndexerExpression"
-    ) {
-        if let Some(steps) = decompose_chain(node) {
-            let span = Span {
-                start: node.byte_start,
-                end: node.byte_end,
-            };
+fn find_answer_refs(expr: &Expr, out: &mut Vec<Annotation>, diagnostics: &mut Vec<Diagnostic>) {
+    let target = unwrap_parens(expr);
+
+    if is_chain_node(target) {
+        if let Some(steps) = decompose_chain(target) {
+            let span = span_of(target);
             match match_qr_path(&steps) {
                 MatchOutcome::Annotation(result) => {
                     let kind = match result.kind {
@@ -776,21 +726,49 @@ fn find_answer_refs(node: &AstNode, out: &mut Vec<Annotation>, diagnostics: &mut
                     return;
                 }
                 MatchOutcome::NotApplicable => {
-                    // Fall through to recurse.
+                    // Fall through to recurse generically.
                 }
             }
         }
     }
 
-    // Recurse into children
-    for child in &node.children {
-        find_answer_refs(child, out, diagnostics);
+    // Recurse into structural sub-expressions.
+    match target {
+        Expr::Binary { lhs, rhs, .. } => {
+            find_answer_refs(lhs, out, diagnostics);
+            find_answer_refs(rhs, out, diagnostics);
+        }
+        Expr::Polarity { operand, .. } => {
+            find_answer_refs(operand, out, diagnostics);
+        }
+        Expr::Type { lhs, .. } => {
+            find_answer_refs(lhs, out, diagnostics);
+        }
+        Expr::Indexer { receiver, index, .. } => {
+            find_answer_refs(receiver, out, diagnostics);
+            find_answer_refs(index, out, diagnostics);
+        }
+        Expr::Invocation { receiver, call, .. } => {
+            if let Some(r) = receiver {
+                find_answer_refs(r, out, diagnostics);
+            }
+            if let Invocation::Function { args, .. } = call {
+                for a in args {
+                    find_answer_refs(a, out, diagnostics);
+                }
+            }
+        }
+        Expr::Parenthesized { inner, .. } => {
+            find_answer_refs(inner, out, diagnostics);
+        }
+        Expr::Literal(_) | Expr::ExternalConstant { .. } => {}
     }
 }
 
-/// Check if a node's byte range overlaps with an annotation span.
-fn overlaps_annotation(node: &AstNode, ann: &Annotation) -> bool {
-    node.byte_start < ann.span.end && node.byte_end > ann.span.start
+/// Check if `expr`'s byte range overlaps with an annotation span.
+fn overlaps_annotation(expr: &Expr, ann: &Annotation) -> bool {
+    let s = expr.span();
+    s.byte_start < ann.span.end && s.byte_end > ann.span.start
 }
 
 /// Find the last linkId from an answer reference annotation.
@@ -801,170 +779,219 @@ fn last_link_id(ann: &Annotation) -> Option<&str> {
     }
 }
 
-/// Try to extract a `%factory.Coding('system', 'code')` invocation from a node.
-fn try_extract_factory_coding(node: &AstNode) -> Option<(String, Option<String>, Span)> {
-    // node should be an InvocationExpression
-    if node.node_type != "InvocationExpression" {
+/// Try to extract a `%factory.Coding('system', 'code')` invocation from an
+/// expression.
+fn try_extract_factory_coding(expr: &Expr) -> Option<(String, Option<String>, Span)> {
+    let expr = unwrap_parens(expr);
+    let Expr::Invocation {
+        receiver: Some(rcv),
+        call,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+
+    // receiver should be %factory
+    let rcv = unwrap_parens(rcv);
+    let Expr::ExternalConstant { ident, .. } = rcv else {
+        return None;
+    };
+    let factory_name = match ident {
+        ExternalConstantId::Identifier(id) => id.raw.as_str(),
+        ExternalConstantId::String { raw, .. } if raw.len() >= 2 => &raw[1..raw.len() - 1],
+        _ => return None,
+    };
+    if factory_name != "factory" {
         return None;
     }
 
-    let receiver = node.children.first()?;
-    let member = node.children.get(1)?;
-
-    // receiver should be TermExpression -> ExternalConstantTerm -> ExternalConstant -> Identifier("factory")
-    if receiver.node_type != "TermExpression" {
+    let Invocation::Function { name, args, .. } = call else {
         return None;
-    }
-    let ext_term = receiver.children.first()?;
-    if ext_term.node_type != "ExternalConstantTerm" {
-        return None;
-    }
-    let ext_const = ext_term.children.first()?;
-    if ext_const.node_type != "ExternalConstant" {
-        return None;
-    }
-    let factory_ident = ext_const.children.first()?;
-    if get_identifier_name(factory_ident)? != "factory" {
+    };
+    if name.raw != "Coding" || args.len() < 2 {
         return None;
     }
 
-    // member should be FunctionInvocation -> Functn with name "Coding"
-    if member.node_type != "FunctionInvocation" {
-        return None;
-    }
-    let functn = member.children.first()?;
-    if functn.node_type != "Functn" {
-        return None;
-    }
-    let func_ident = functn.children.first()?;
-    if get_identifier_name(func_ident)? != "Coding" {
-        return None;
-    }
+    let system = extract_string_value(&args[0])?;
+    let code = extract_string_value(&args[1])?;
 
-    // ParamList with >= 2 children
-    let param_list = functn.children.get(1)?;
-    if param_list.node_type != "ParamList" || param_list.children.len() < 2 {
-        return None;
-    }
-
-    let system = extract_string_value(param_list.children.first()?)?;
-    let code = extract_string_value(param_list.children.get(1)?)?;
-
-    Some((
-        code,
-        Some(system),
-        Span {
-            start: node.byte_start,
-            end: node.byte_end,
-        },
-    ))
+    Some((code, Some(system), span_of(expr)))
 }
 
-/// Try to extract a string literal value and span from a node by searching its subtree.
-fn try_extract_string_literal(node: &AstNode) -> Option<(String, Span)> {
-    if let Some(val) = extract_string_value(node) {
-        return Some((
-            val,
-            Span {
-                start: node.byte_start,
-                end: node.byte_end,
-            },
-        ));
+/// Try to extract a string literal value and span from an expression by
+/// searching its subtree.
+fn try_extract_string_literal(expr: &Expr) -> Option<(String, Span)> {
+    let target = unwrap_parens(expr);
+    if let Some(val) = extract_string_value(target) {
+        return Some((val, span_of(target)));
     }
-    // Recurse into children
-    for child in &node.children {
-        if let Some(result) = try_extract_string_literal(child) {
-            return Some(result);
+    // Recurse — we need to mirror the legacy behavior which descended via
+    // `.children`. Walk the structural sub-expressions.
+    match target {
+        Expr::Binary { lhs, rhs, .. } => try_extract_string_literal(lhs)
+            .or_else(|| try_extract_string_literal(rhs)),
+        Expr::Polarity { operand, .. } => try_extract_string_literal(operand),
+        Expr::Type { lhs, .. } => try_extract_string_literal(lhs),
+        Expr::Indexer { receiver, index, .. } => try_extract_string_literal(receiver)
+            .or_else(|| try_extract_string_literal(index)),
+        Expr::Invocation { receiver, call, .. } => {
+            if let Some(r) = receiver {
+                if let Some(v) = try_extract_string_literal(r) {
+                    return Some(v);
+                }
+            }
+            if let Invocation::Function { args, .. } = call {
+                for a in args {
+                    if let Some(v) = try_extract_string_literal(a) {
+                        return Some(v);
+                    }
+                }
+            }
+            None
         }
+        Expr::Parenthesized { inner, .. } => try_extract_string_literal(inner),
+        Expr::Literal(_) | Expr::ExternalConstant { .. } => None,
     }
-    None
 }
 
-/// Try to extract a factory coding from a node by searching its subtree.
-fn try_extract_factory_coding_recursive(node: &AstNode) -> Option<(String, Option<String>, Span)> {
-    if let Some(result) = try_extract_factory_coding(node) {
+/// Try to extract a factory coding from an expression by searching its subtree.
+fn try_extract_factory_coding_recursive(expr: &Expr) -> Option<(String, Option<String>, Span)> {
+    if let Some(result) = try_extract_factory_coding(expr) {
         return Some(result);
     }
-    for child in &node.children {
-        if let Some(result) = try_extract_factory_coding_recursive(child) {
-            return Some(result);
+    let target = unwrap_parens(expr);
+    match target {
+        Expr::Binary { lhs, rhs, .. } => try_extract_factory_coding_recursive(lhs)
+            .or_else(|| try_extract_factory_coding_recursive(rhs)),
+        Expr::Polarity { operand, .. } => try_extract_factory_coding_recursive(operand),
+        Expr::Type { lhs, .. } => try_extract_factory_coding_recursive(lhs),
+        Expr::Indexer { receiver, index, .. } => try_extract_factory_coding_recursive(receiver)
+            .or_else(|| try_extract_factory_coding_recursive(index)),
+        Expr::Invocation { receiver, call, .. } => {
+            if let Some(r) = receiver {
+                if let Some(v) = try_extract_factory_coding_recursive(r) {
+                    return Some(v);
+                }
+            }
+            if let Invocation::Function { args, .. } = call {
+                for a in args {
+                    if let Some(v) = try_extract_factory_coding_recursive(a) {
+                        return Some(v);
+                    }
+                }
+            }
+            None
         }
+        Expr::Parenthesized { inner, .. } => try_extract_factory_coding_recursive(inner),
+        Expr::Literal(_) | Expr::ExternalConstant { .. } => None,
     }
-    None
 }
 
-/// Check if a node is fully contained within any answer ref annotation.
-fn contained_in_answer_ref(node: &AstNode, answer_refs: &[Annotation]) -> bool {
-    answer_refs.iter().any(|a| node.byte_start >= a.span.start && node.byte_end <= a.span.end)
+/// Check if an expression is fully contained within any answer ref annotation.
+fn contained_in_answer_ref(expr: &Expr, answer_refs: &[Annotation]) -> bool {
+    let s = expr.span();
+    answer_refs
+        .iter()
+        .any(|a| s.byte_start >= a.span.start && s.byte_end <= a.span.end)
 }
 
-/// Pass 2: Find coded values by scanning for equality/equivalence expressions that compare
-/// an answer reference against a code literal or factory Coding.
-fn find_coded_values(node: &AstNode, answer_refs: &[Annotation], out: &mut Vec<Annotation>) {
-    // Skip nodes fully contained within an answer ref (e.g. the linkId='x' inside where())
-    if contained_in_answer_ref(node, answer_refs) {
+/// Pass 2: Find coded values by scanning for equality/equivalence expressions
+/// that compare an answer reference against a code literal or factory Coding.
+fn find_coded_values(expr: &Expr, answer_refs: &[Annotation], out: &mut Vec<Annotation>) {
+    // Skip nodes fully contained within an answer ref (e.g. the linkId='x' inside where()).
+    if contained_in_answer_ref(expr, answer_refs) {
         return;
     }
 
-    if node.node_type == "EqualityExpression" && node.children.len() == 2 {
-        let left = &node.children[0];
-        let right = &node.children[1];
+    let target = unwrap_parens(expr);
 
-        // Find which side overlaps an answer ref
-        let (answer_ref, code_side) =
-            if let Some(ann) = answer_refs.iter().find(|a| overlaps_annotation(left, a)) {
-                (ann, right)
-            } else if let Some(ann) = answer_refs.iter().find(|a| overlaps_annotation(right, a)) {
-                (ann, left)
-            } else {
-                // No answer ref found, recurse into children
-                for child in &node.children {
-                    find_coded_values(child, answer_refs, out);
+    // Equality-family operators (=, !=, ~, !~) all lower to "EqualityExpression"
+    // in the legacy tree. We only need to look for those.
+    if let Expr::Binary { op, lhs, rhs, .. } = target {
+        if matches!(
+            op,
+            BinOp::Eq | BinOp::NotEq | BinOp::EquivTilde | BinOp::NotEquivTilde
+        ) {
+            let (answer_ref, code_side) =
+                if let Some(ann) = answer_refs.iter().find(|a| overlaps_annotation(lhs, a)) {
+                    (ann, rhs.as_ref())
+                } else if let Some(ann) = answer_refs.iter().find(|a| overlaps_annotation(rhs, a)) {
+                    (ann, lhs.as_ref())
+                } else {
+                    find_coded_values(lhs, answer_refs, out);
+                    find_coded_values(rhs, answer_refs, out);
+                    return;
+                };
+
+            let context_link_id = match last_link_id(answer_ref) {
+                Some(id) => id.to_string(),
+                None => {
+                    find_coded_values(lhs, answer_refs, out);
+                    find_coded_values(rhs, answer_refs, out);
+                    return;
                 }
-                return;
             };
 
-        let context_link_id = match last_link_id(answer_ref) {
-            Some(id) => id.to_string(),
-            None => {
-                for child in &node.children {
-                    find_coded_values(child, answer_refs, out);
-                }
+            // Try factory coding first, then string literal
+            if let Some((code, system, span)) = try_extract_factory_coding_recursive(code_side) {
+                out.push(Annotation {
+                    span,
+                    kind: AnnotationKind::CodedValue {
+                        code,
+                        system,
+                        context_link_id,
+                    },
+                    attribution: Attribution::Full,
+                });
                 return;
             }
-        };
 
-        // Try factory coding first, then string literal
-        if let Some((code, system, span)) = try_extract_factory_coding_recursive(code_side) {
-            out.push(Annotation {
-                span,
-                kind: AnnotationKind::CodedValue {
-                    code,
-                    system,
-                    context_link_id,
-                },
-                attribution: Attribution::Full,
-            });
-            return;
-        }
-
-        if let Some((value, span)) = try_extract_string_literal(code_side) {
-            out.push(Annotation {
-                span,
-                kind: AnnotationKind::CodedValue {
-                    code: value,
-                    system: None,
-                    context_link_id,
-                },
-                attribution: Attribution::Full,
-            });
-            return;
+            if let Some((value, span)) = try_extract_string_literal(code_side) {
+                out.push(Annotation {
+                    span,
+                    kind: AnnotationKind::CodedValue {
+                        code: value,
+                        system: None,
+                        context_link_id,
+                    },
+                    attribution: Attribution::Full,
+                });
+                return;
+            }
         }
     }
 
-    // Recurse into children
-    for child in &node.children {
-        find_coded_values(child, answer_refs, out);
+    // Recurse into structural children
+    match target {
+        Expr::Binary { lhs, rhs, .. } => {
+            find_coded_values(lhs, answer_refs, out);
+            find_coded_values(rhs, answer_refs, out);
+        }
+        Expr::Polarity { operand, .. } => {
+            find_coded_values(operand, answer_refs, out);
+        }
+        Expr::Type { lhs, .. } => {
+            find_coded_values(lhs, answer_refs, out);
+        }
+        Expr::Indexer { receiver, index, .. } => {
+            find_coded_values(receiver, answer_refs, out);
+            find_coded_values(index, answer_refs, out);
+        }
+        Expr::Invocation { receiver, call, .. } => {
+            if let Some(r) = receiver {
+                find_coded_values(r, answer_refs, out);
+            }
+            if let Invocation::Function { args, .. } = call {
+                for a in args {
+                    find_coded_values(a, answer_refs, out);
+                }
+            }
+        }
+        Expr::Parenthesized { inner, .. } => {
+            find_coded_values(inner, answer_refs, out);
+        }
+        Expr::Literal(_) | Expr::ExternalConstant { .. } => {}
     }
 }
 
@@ -990,18 +1017,15 @@ pub(crate) fn annotate_expression_with_diagnostics(
 /// (notably `result_type::infer_result_type`) instead of reparsing.
 pub(crate) fn annotate_expression_with_ast(
     expr: &str,
-) -> Result<(crate::ast::Expr, Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
-    let tokens = crate::lexer::tokenize(expr)?;
-    let mut p = crate::parser::Parser::new(&tokens);
-    let typed = p.parse_entire_expression()?;
-    let root = crate::compat::lower(&typed, &tokens);
+) -> Result<(Expr, Vec<Annotation>, Vec<Diagnostic>), crate::ParseError> {
+    let typed = crate::parse(expr)?;
 
     let mut answer_refs = Vec::new();
     let mut diagnostics = Vec::new();
-    find_answer_refs(&root, &mut answer_refs, &mut diagnostics);
+    find_answer_refs(&typed, &mut answer_refs, &mut diagnostics);
 
     let mut coded_values = Vec::new();
-    find_coded_values(&root, &answer_refs, &mut coded_values);
+    find_coded_values(&typed, &answer_refs, &mut coded_values);
 
     let mut all: Vec<Annotation> = answer_refs.into_iter().chain(coded_values).collect();
     all.sort_by_key(|a| a.span.start);

--- a/src/analyze/completions.rs
+++ b/src/analyze/completions.rs
@@ -41,12 +41,9 @@ enum ContextPosition {
 }
 
 fn resolve_context(expr: &str) -> Result<Option<ContextPosition>, crate::ParseError> {
-    let tokens = crate::lexer::tokenize(expr)?;
-    let mut p = crate::parser::Parser::new(&tokens);
-    let typed = p.parse_entire_expression()?;
-    let root = crate::compat::lower(&typed, &tokens);
+    let typed = crate::parse(expr)?;
 
-    let steps = match decompose_chain(&root) {
+    let steps = match decompose_chain(&typed) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -328,10 +328,11 @@ pub fn analyze_expression(
 
     if let Some(expected) = context.expected_result_type {
         if inferred_type != InferredType::Unknown && inferred_type != expected {
+            let s = ast.span();
             diagnostics.push(Diagnostic {
                 span: Span {
-                    start: ast.byte_start,
-                    end: ast.byte_end,
+                    start: s.byte_start,
+                    end: s.byte_end,
                 },
                 severity: Severity::Error,
                 code: DiagnosticCode::ExpressionTypeMismatch,
@@ -346,10 +347,11 @@ pub fn analyze_expression(
 
     if let Some(expected) = context.expected_cardinality {
         if inferred_cardinality != Cardinality::Unknown && inferred_cardinality != expected {
+            let s = ast.span();
             diagnostics.push(Diagnostic {
                 span: Span {
-                    start: ast.byte_start,
-                    end: ast.byte_end,
+                    start: s.byte_start,
+                    end: s.byte_end,
                 },
                 severity: Severity::Error,
                 code: DiagnosticCode::ExpressionCardinalityMismatch,

--- a/src/analyze/result_type.rs
+++ b/src/analyze/result_type.rs
@@ -14,7 +14,7 @@ use crate::analyze::questionnaire_index::QuestionnaireIndex;
 use crate::analyze::{
     Annotation, AnnotationKind, Attribution, Cardinality, InferredType, ValueAccessor,
 };
-use crate::compat::AstNode;
+use crate::ast::{BinOp, Expr, Invocation, Literal, TypeOp, TypeSpecifier};
 
 /// Map a Questionnaire item type + value-accessor to an inferred result type.
 ///
@@ -40,36 +40,11 @@ fn answer_leaf_type(item_type: &str, accessor: &ValueAccessor) -> InferredType {
     }
 }
 
-/// Look up the function name from a `FunctionInvocation` AST node.
-fn function_name(fi: &AstNode) -> Option<&str> {
-    if fi.node_type != "FunctionInvocation" {
-        return None;
-    }
-    let functn = fi.children.first()?;
-    if functn.node_type != "Functn" {
-        return None;
-    }
-    let ident = functn.children.first()?;
-    if ident.node_type != "Identifier" {
-        return None;
-    }
-    ident.terminal_node_text.first().map(|s| s.as_str())
-}
-
 /// Read the type-spec name out of a `TypeSpecifier` (used by `is` / `as` /
 /// `ofType`). Returns the unqualified head identifier — good enough for
 /// matching well-known FHIRPath / FHIR primitive names.
-fn type_specifier_name(node: &AstNode) -> Option<&str> {
-    if node.node_type != "TypeSpecifier" {
-        return None;
-    }
-    let qi = node.children.first()?;
-    // QualifiedIdentifier { children: [Identifier, ...] }
-    let first_part = qi.children.first()?;
-    if first_part.node_type != "Identifier" {
-        return None;
-    }
-    first_part.terminal_node_text.first().map(|s| s.as_str())
+fn type_specifier_name(ts: &TypeSpecifier) -> Option<&str> {
+    ts.qualified.parts.first().map(|id| id.raw.as_str())
 }
 
 /// Map a FHIR / FHIRPath type specifier name (e.g. `Boolean`, `boolean`,
@@ -91,13 +66,32 @@ fn type_name_to_inferred(name: &str) -> InferredType {
     }
 }
 
+/// If the argument is itself an `Expr::Invocation` with a Member call whose
+/// identifier names a type, return that name. Used by `ofType(Coding)` etc.
+fn arg_to_type_name(expr: &Expr) -> Option<&str> {
+    let expr = unwrap_passthrough(expr);
+    match expr {
+        Expr::Invocation {
+            receiver: None,
+            call: Invocation::Member { ident },
+            ..
+        } => Some(ident.raw.as_str()),
+        _ => None,
+    }
+}
+
+/// Read the type-spec name from a `Type` expression's TypeSpecifier.
+fn type_op_name(ts: &TypeSpecifier) -> Option<&str> {
+    type_specifier_name(ts)
+}
+
 /// Result-type lookup for a function call, given the (already-inferred) type
 /// of its receiver chain. `args` is the list of argument expressions if any
 /// (for `ofType`, `as`, `iif`).
 fn function_result_type(
     name: &str,
     receiver: InferredType,
-    args: &[&AstNode],
+    args: &[&Expr],
     index: &QuestionnaireIndex,
     annotations: &[Annotation],
 ) -> InferredType {
@@ -172,7 +166,7 @@ fn function_result_type(
     // ── Type-asserting (preserve the asserted type) ──────────────────────
     if name == "ofType" || name == "as" {
         if let Some(arg) = args.first() {
-            if let Some(tn) = type_specifier_name(arg) {
+            if let Some(tn) = arg_to_type_name(arg) {
                 return type_name_to_inferred(tn);
             }
         }
@@ -209,39 +203,24 @@ fn function_result_type(
     }
 }
 
-/// Strip wrapper nodes that don't affect type (`TermExpression`,
-/// `ParenthesizedTerm`, `LiteralTerm`, `InvocationTerm`).
-fn unwrap_passthrough<'a>(mut node: &'a AstNode) -> &'a AstNode {
-    loop {
-        match node.node_type {
-            "TermExpression" | "LiteralTerm" | "InvocationTerm" => {
-                if let Some(c) = node.children.first() {
-                    node = c;
-                } else {
-                    return node;
-                }
-            }
-            "ParenthesizedTerm" => {
-                if let Some(c) = node.children.first() {
-                    node = c;
-                } else {
-                    return node;
-                }
-            }
-            _ => return node,
-        }
+/// Strip parenthesized wrappers that don't affect type/cardinality.
+fn unwrap_passthrough(mut node: &Expr) -> &Expr {
+    while let Expr::Parenthesized { inner, .. } = node {
+        node = inner;
     }
+    node
 }
 
 /// Try to resolve an InvocationExpression chain to an answer-leaf type by
 /// matching it against an existing annotation.
 fn answer_leaf_for_chain(
-    node: &AstNode,
+    node: &Expr,
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> Option<InferredType> {
+    let span = node.span();
     for ann in annotations {
-        if ann.span.start != node.byte_start || ann.span.end != node.byte_end {
+        if ann.span.start != span.byte_start || ann.span.end != span.byte_end {
             continue;
         }
         // Skip degraded attribution — path is no longer precise.
@@ -261,208 +240,145 @@ fn answer_leaf_for_chain(
 }
 
 /// Recursive type inference on a single AST node.
-fn infer_node(node: &AstNode, annotations: &[Annotation], index: &QuestionnaireIndex) -> InferredType {
+fn infer_node(node: &Expr, annotations: &[Annotation], index: &QuestionnaireIndex) -> InferredType {
     let node = unwrap_passthrough(node);
 
-    match node.node_type {
+    match node {
         // ── Literals ──
-        "BooleanLiteral" => InferredType::Boolean,
-        "StringLiteral" => InferredType::String,
-        "NumberLiteral" => {
-            let raw = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if raw.contains('.') {
-                InferredType::Decimal
-            } else {
-                InferredType::Integer
+        Expr::Literal(lit) => match lit {
+            Literal::Boolean { .. } => InferredType::Boolean,
+            Literal::String { .. } => InferredType::String,
+            Literal::Number { raw, .. } => {
+                if raw.contains('.') {
+                    InferredType::Decimal
+                } else {
+                    InferredType::Integer
+                }
             }
-        }
-        "DateTimeLiteral" => {
-            // FHIRPath date-time literals start with `@`. Presence of `T`
-            // distinguishes a date-time from a bare date.
-            let raw = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if raw.contains('T') {
-                InferredType::DateTime
-            } else {
-                InferredType::Date
+            Literal::DateTime { raw, .. } => {
+                // FHIRPath date-time literals start with `@`. Presence of `T`
+                // distinguishes a date-time from a bare date.
+                if raw.contains('T') {
+                    InferredType::DateTime
+                } else {
+                    InferredType::Date
+                }
             }
-        }
-        "TimeLiteral" => InferredType::Time,
-        "QuantityLiteral" => InferredType::Quantity,
-        "NullLiteral" => InferredType::Unknown,
+            Literal::Time { .. } => InferredType::Time,
+            Literal::Quantity { .. } => InferredType::Quantity,
+            Literal::Null { .. } => InferredType::Unknown,
+        },
 
         // ── Boolean-producing operators ──
-        "EqualityExpression"
-        | "InequalityExpression"
-        | "MembershipExpression"
-        | "AndExpression"
-        | "OrExpression"
-        | "ImpliesExpression" => InferredType::Boolean,
+        Expr::Binary { op, lhs, rhs, .. } => match op {
+            BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::EquivTilde
+            | BinOp::NotEquivTilde
+            | BinOp::Lt
+            | BinOp::Gt
+            | BinOp::LtEq
+            | BinOp::GtEq
+            | BinOp::In
+            | BinOp::Contains
+            | BinOp::And
+            | BinOp::Or
+            | BinOp::Xor
+            | BinOp::Implies => InferredType::Boolean,
 
-        "TypeExpression" => {
-            let op = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if op == "is" {
-                InferredType::Boolean
-            } else if op == "as" {
-                // `expr as Type` → inferred type from the TypeSpecifier.
-                node.children
-                    .get(1)
-                    .and_then(type_specifier_name)
-                    .map(type_name_to_inferred)
-                    .unwrap_or(InferredType::Unknown)
-            } else {
-                InferredType::Unknown
-            }
-        }
+            BinOp::Concat => InferredType::String,
 
-        // ── Arithmetic ──
-        "AdditiveExpression" => {
-            let op = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if op == "&" {
-                return InferredType::String;
+            BinOp::Plus | BinOp::Minus => {
+                let l = infer_node(lhs, annotations, index);
+                let r = infer_node(rhs, annotations, index);
+                numeric_combine(l, r)
             }
-            let left = node
-                .children
-                .first()
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            let right = node
-                .children
-                .get(1)
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            numeric_combine(left, right)
-        }
-        "MultiplicativeExpression" => {
-            let left = node
-                .children
-                .first()
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            let right = node
-                .children
-                .get(1)
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            // div / mod produce Integer when both sides are Integer; otherwise
-            // pass through the numeric combine rules.
-            let op = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if op == "div" || op == "mod" {
-                if matches!(left, InferredType::Integer)
-                    && matches!(right, InferredType::Integer)
+            BinOp::Mul => {
+                let l = infer_node(lhs, annotations, index);
+                let r = infer_node(rhs, annotations, index);
+                numeric_combine(l, r)
+            }
+            BinOp::TrueDiv => {
+                let l = infer_node(lhs, annotations, index);
+                let r = infer_node(rhs, annotations, index);
+                if matches!(l, InferredType::Integer | InferredType::Decimal)
+                    && matches!(r, InferredType::Integer | InferredType::Decimal)
                 {
-                    return InferredType::Integer;
+                    InferredType::Decimal
+                } else {
+                    numeric_combine(l, r)
                 }
-                if matches!(
-                    left,
-                    InferredType::Integer | InferredType::Decimal
-                ) && matches!(
-                    right,
-                    InferredType::Integer | InferredType::Decimal
-                ) {
-                    return InferredType::Decimal;
+            }
+            BinOp::IntDiv | BinOp::Mod => {
+                let l = infer_node(lhs, annotations, index);
+                let r = infer_node(rhs, annotations, index);
+                if matches!(l, InferredType::Integer) && matches!(r, InferredType::Integer) {
+                    InferredType::Integer
+                } else if matches!(l, InferredType::Integer | InferredType::Decimal)
+                    && matches!(r, InferredType::Integer | InferredType::Decimal)
+                {
+                    InferredType::Decimal
+                } else {
+                    InferredType::Unknown
                 }
-                return InferredType::Unknown;
             }
-            // `/` always yields Decimal in FHIRPath
-            if op == "/"
-                && matches!(left, InferredType::Integer | InferredType::Decimal)
-                && matches!(right, InferredType::Integer | InferredType::Decimal)
-            {
-                return InferredType::Decimal;
+            // Union `a | b` — same type if both operands agree, else Unknown.
+            BinOp::Union => {
+                let l = infer_node(lhs, annotations, index);
+                let r = infer_node(rhs, annotations, index);
+                if l == r {
+                    l
+                } else {
+                    InferredType::Unknown
+                }
             }
-            numeric_combine(left, right)
-        }
-        "PolarityExpression" => node
-            .children
-            .first()
-            .map(|c| infer_node(c, annotations, index))
-            .unwrap_or(InferredType::Unknown),
+        },
 
-        // ── Function chains ──
-        "InvocationExpression" => {
+        Expr::Type { op, type_spec, .. } => match op {
+            TypeOp::Is => InferredType::Boolean,
+            TypeOp::As => type_op_name(type_spec)
+                .map(type_name_to_inferred)
+                .unwrap_or(InferredType::Unknown),
+        },
+
+        Expr::Polarity { operand, .. } => infer_node(operand, annotations, index),
+
+        // Bracket index `expr[i]` — type of the receiver.
+        Expr::Indexer { receiver, .. } => infer_node(receiver, annotations, index),
+
+        // ── Invocations (chained or standalone) ──
+        Expr::Invocation { receiver, call, .. } => {
             // First, try to match this whole chain against an annotation so
             // an answer-leaf chain (e.g. `item.where(linkId='x').answer.value`)
             // resolves via the QuestionnaireIndex.
-            if let Some(t) = answer_leaf_for_chain(node, annotations, index) {
-                return t;
-            }
-            // Otherwise: examine the rightmost call.
-            let receiver = node.children.first();
-            let member = node.children.get(1);
-            match (receiver, member) {
-                (Some(recv), Some(mem)) => {
-                    if mem.node_type == "FunctionInvocation" {
-                        let name = function_name(mem).unwrap_or("");
-                        let recv_t = infer_node(recv, annotations, index);
-                        let args = function_args(mem);
-                        function_result_type(name, recv_t, &args, index, annotations)
-                    } else {
-                        // Member access on something — we can't generally know
-                        // the field type without a schema. Boolean-returning
-                        // member names are rare; default to Unknown.
-                        InferredType::Unknown
-                    }
+            if receiver.is_some() {
+                if let Some(t) = answer_leaf_for_chain(node, annotations, index) {
+                    return t;
                 }
-                _ => InferredType::Unknown,
+            }
+            match call {
+                Invocation::Function { name, args, .. } => {
+                    let recv_t = match receiver {
+                        Some(r) => infer_node(r, annotations, index),
+                        None => InferredType::Unknown,
+                    };
+                    let arg_refs: Vec<&Expr> = args.iter().collect();
+                    function_result_type(&name.raw, recv_t, &arg_refs, index, annotations)
+                }
+                // Member access on something — we can't generally know
+                // the field type without a schema. Boolean-returning
+                // member names are rare; default to Unknown.
+                Invocation::Member { .. } => InferredType::Unknown,
+                Invocation::This { .. } | Invocation::Index { .. } | Invocation::Total { .. } => {
+                    InferredType::Unknown
+                }
             }
         }
 
-        // Standalone function call: TermExpression -> InvocationTerm ->
-        // FunctionInvocation. After unwrap_passthrough we may already be at
-        // FunctionInvocation.
-        "FunctionInvocation" => {
-            let name = function_name(node).unwrap_or("");
-            let args = function_args(node);
-            function_result_type(name, InferredType::Unknown, &args, index, annotations)
-        }
+        // External constants — opaque without binding info.
+        Expr::ExternalConstant { .. } => InferredType::Unknown,
 
-        // Bracket index `expr[i]` — type of the receiver.
-        "IndexerExpression" => node
-            .children
-            .first()
-            .map(|c| infer_node(c, annotations, index))
-            .unwrap_or(InferredType::Unknown),
-
-        // Union `a | b` — same type if both operands agree, else Unknown.
-        "UnionExpression" => {
-            let left = node
-                .children
-                .first()
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            let right = node
-                .children
-                .get(1)
-                .map(|c| infer_node(c, annotations, index))
-                .unwrap_or(InferredType::Unknown);
-            if left == right {
-                left
-            } else {
-                InferredType::Unknown
-            }
-        }
-
-        _ => InferredType::Unknown,
+        Expr::Parenthesized { .. } => unreachable!("stripped by unwrap_passthrough"),
     }
 }
 
@@ -478,27 +394,9 @@ fn numeric_combine(left: InferredType, right: InferredType) -> InferredType {
     }
 }
 
-/// Collect the argument expressions from a FunctionInvocation node.
-fn function_args(fi: &AstNode) -> Vec<&AstNode> {
-    let Some(functn) = fi.children.first() else {
-        return Vec::new();
-    };
-    if functn.node_type != "Functn" {
-        return Vec::new();
-    }
-    // children: [Identifier, ParamList?]
-    let Some(param_list) = functn.children.get(1) else {
-        return Vec::new();
-    };
-    if param_list.node_type != "ParamList" {
-        return Vec::new();
-    }
-    param_list.children.iter().collect()
-}
-
 /// Public entry point: infer the result type of a parsed FHIRPath expression.
 pub(crate) fn infer_result_type(
-    ast: &AstNode,
+    ast: &Expr,
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> InferredType {
@@ -561,7 +459,7 @@ fn function_cardinality(name: &str) -> Option<FnCardinality> {
 
 /// `take(n)` collapses to Singleton only when `n == 1`. Otherwise it's a
 /// pass-through cap (could keep the receiver's cardinality up to n elements).
-fn take_cardinality(args: &[&AstNode], receiver: Cardinality) -> Cardinality {
+fn take_cardinality(args: &[&Expr], receiver: Cardinality) -> Cardinality {
     let Some(arg) = args.first() else {
         return Cardinality::Unknown;
     };
@@ -574,25 +472,23 @@ fn take_cardinality(args: &[&AstNode], receiver: Cardinality) -> Cardinality {
     Cardinality::Unknown
 }
 
-/// Pull an integer value out of a literal expression, peeling wrappers.
-fn literal_integer(node: &AstNode) -> Option<i64> {
+/// Pull an integer value out of a literal expression, peeling parens.
+fn literal_integer(node: &Expr) -> Option<i64> {
     let inner = unwrap_passthrough(node);
-    if inner.node_type != "NumberLiteral" {
-        return None;
+    match inner {
+        Expr::Literal(Literal::Number { raw, .. }) => raw.parse::<i64>().ok(),
+        _ => None,
     }
-    inner
-        .terminal_node_text
-        .first()
-        .and_then(|s| s.parse::<i64>().ok())
 }
 
 fn answer_leaf_cardinality_for_chain(
-    node: &AstNode,
+    node: &Expr,
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> Option<Cardinality> {
+    let span = node.span();
     for ann in annotations {
-        if ann.span.start != node.byte_start || ann.span.end != node.byte_end {
+        if ann.span.start != span.byte_start || ann.span.end != span.byte_end {
             continue;
         }
         match ann.attribution {
@@ -624,109 +520,79 @@ fn answer_leaf_cardinality_for_chain(
 }
 
 fn infer_card_node(
-    node: &AstNode,
+    node: &Expr,
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> Cardinality {
     let node = unwrap_passthrough(node);
 
-    match node.node_type {
+    match node {
         // ── Literals: always one ──
-        "BooleanLiteral" | "StringLiteral" | "NumberLiteral" | "DateTimeLiteral"
-        | "TimeLiteral" | "QuantityLiteral" | "NullLiteral" => Cardinality::Singleton,
+        Expr::Literal(_) => Cardinality::Singleton,
 
         // External constants — `%foo` resolves to whatever is bound. Treat as
         // unknown rather than guessing.
-        "ExternalConstant" | "ExternalConstantTerm" => Cardinality::Unknown,
-
-        // Context vars: `$this`/`$index`/`$total` are scalars per spec.
-        "ThisInvocation" | "IndexInvocation" | "TotalInvocation" => Cardinality::Singleton,
+        Expr::ExternalConstant { .. } => Cardinality::Unknown,
 
         // ── Boolean and arithmetic operators all return a singleton ──
-        "EqualityExpression"
-        | "InequalityExpression"
-        | "MembershipExpression"
-        | "AndExpression"
-        | "OrExpression"
-        | "ImpliesExpression"
-        | "AdditiveExpression"
-        | "MultiplicativeExpression"
-        | "PolarityExpression" => Cardinality::Singleton,
+        Expr::Binary { op, .. } => match op {
+            // Union always Collection
+            BinOp::Union => Cardinality::Collection,
+            _ => Cardinality::Singleton,
+        },
 
-        "TypeExpression" => {
-            let op = node
-                .terminal_node_text
-                .first()
-                .map(|s| s.as_str())
-                .unwrap_or("");
-            if op == "is" {
-                Cardinality::Singleton
-            } else {
-                // `as` preserves the operand's cardinality.
-                node.children
-                    .first()
-                    .map(|c| infer_card_node(c, annotations, index))
-                    .unwrap_or(Cardinality::Unknown)
-            }
-        }
+        Expr::Type { op, lhs, .. } => match op {
+            TypeOp::Is => Cardinality::Singleton,
+            // `as` preserves the operand's cardinality.
+            TypeOp::As => infer_card_node(lhs, annotations, index),
+        },
 
-        // ── Union always Collection ──
-        "UnionExpression" => Cardinality::Collection,
+        Expr::Polarity { .. } => Cardinality::Singleton,
 
         // ── Indexer: single element ──
-        "IndexerExpression" => Cardinality::Singleton,
+        Expr::Indexer { .. } => Cardinality::Singleton,
 
-        // ── Function chains ──
-        "InvocationExpression" => {
+        // ── Invocations ──
+        Expr::Invocation { receiver, call, .. } => {
             // Answer-leaf chain: defer to questionnaire metadata.
-            if let Some(c) = answer_leaf_cardinality_for_chain(node, annotations, index) {
-                return c;
-            }
-            let receiver = node.children.first();
-            let member = node.children.get(1);
-            match (receiver, member) {
-                (Some(recv), Some(mem)) => {
-                    if mem.node_type == "FunctionInvocation" {
-                        let name = function_name(mem).unwrap_or("");
-                        let recv_card = infer_card_node(recv, annotations, index);
-                        let args = function_args(mem);
-                        function_cardinality_dispatch(
-                            name,
-                            recv_card,
-                            &args,
-                            annotations,
-                            index,
-                        )
-                    } else {
-                        // Plain member access. Without a FHIR schema we
-                        // can't know whether the field is 0..1 or 0..*.
-                        Cardinality::Unknown
-                    }
+            if receiver.is_some() {
+                if let Some(c) = answer_leaf_cardinality_for_chain(node, annotations, index) {
+                    return c;
                 }
-                _ => Cardinality::Unknown,
+            }
+            match call {
+                Invocation::Function { name, args, .. } => {
+                    let recv_card = match receiver {
+                        Some(r) => infer_card_node(r, annotations, index),
+                        None => Cardinality::Unknown,
+                    };
+                    let arg_refs: Vec<&Expr> = args.iter().collect();
+                    function_cardinality_dispatch(
+                        &name.raw,
+                        recv_card,
+                        &arg_refs,
+                        annotations,
+                        index,
+                    )
+                }
+                // Bare identifier in invocation position (e.g. `Patient`). With no
+                // schema we can't say.
+                Invocation::Member { .. } => Cardinality::Unknown,
+                // Context vars: `$this`/`$index`/`$total` are scalars per spec.
+                Invocation::This { .. } | Invocation::Index { .. } | Invocation::Total { .. } => {
+                    Cardinality::Singleton
+                }
             }
         }
 
-        // Standalone function call (after unwrap_passthrough we may already
-        // be at FunctionInvocation).
-        "FunctionInvocation" => {
-            let name = function_name(node).unwrap_or("");
-            let args = function_args(node);
-            function_cardinality_dispatch(name, Cardinality::Unknown, &args, annotations, index)
-        }
-
-        // Bare identifier in invocation position (e.g. `Patient`). With no
-        // schema we can't say.
-        "MemberInvocation" => Cardinality::Unknown,
-
-        _ => Cardinality::Unknown,
+        Expr::Parenthesized { .. } => unreachable!("stripped by unwrap_passthrough"),
     }
 }
 
 fn function_cardinality_dispatch(
     name: &str,
     receiver: Cardinality,
-    args: &[&AstNode],
+    args: &[&Expr],
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> Cardinality {
@@ -765,7 +631,7 @@ fn function_cardinality_dispatch(
 
 /// Public entry point: infer the cardinality of a parsed FHIRPath expression.
 pub(crate) fn infer_cardinality(
-    ast: &AstNode,
+    ast: &Expr,
     annotations: &[Annotation],
     index: &QuestionnaireIndex,
 ) -> Cardinality {

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -1,23 +1,23 @@
 use crate::analyze::annotations::{decompose_chain, ChainStepKind};
 use crate::analyze::questionnaire_index::QuestionnaireIndex;
 use crate::analyze::{Diagnostic, DiagnosticCode, Severity, Span};
-use crate::compat::AstNode;
+use crate::ast::{Expr, Invocation};
 
 /// Collect all linkIds referenced in where(linkId='...') clauses throughout the AST.
 /// Returns Vec of (linkId_value, span_of_the_literal).
-fn collect_link_id_references(node: &AstNode) -> Vec<(String, Span)> {
+fn collect_link_id_references(expr: &Expr) -> Vec<(String, Span)> {
     let mut refs = Vec::new();
-    collect_link_ids_recursive(node, &mut refs);
+    collect_link_ids_recursive(expr, &mut refs);
     refs
 }
 
-fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
+fn collect_link_ids_recursive(expr: &Expr, out: &mut Vec<(String, Span)>) {
     // Try to decompose this node as a chain and extract linkIds from where() steps
     if matches!(
-        node.node_type,
-        "InvocationExpression" | "TermExpression" | "IndexerExpression"
+        expr,
+        Expr::Invocation { .. } | Expr::Indexer { .. } | Expr::ExternalConstant { .. }
     ) {
-        if let Some(steps) = decompose_chain(node) {
+        if let Some(steps) = decompose_chain(expr) {
             for step in &steps {
                 if let ChainStepKind::Function {
                     name,
@@ -32,16 +32,39 @@ fn collect_link_ids_recursive(node: &AstNode, out: &mut Vec<(String, Span)>) {
                     }
                 }
             }
-            // Skip recursing into children — the chain decomposition from the outermost
-            // node already captures all linkIds, and inner InvocationExpression nodes
-            // would produce duplicates.
+            // Match legacy behavior: skip recursing into children entirely
+            // after a chain match. The chain decomposition from the outermost
+            // node already captures all top-level linkIds, and inner Invocation
+            // nodes would produce duplicates. (Side effect: linkIds buried in
+            // non-linkId where-predicates aren't validated — preserved as-is.)
             return;
         }
     }
 
-    // Recurse into children
-    for child in &node.children {
-        collect_link_ids_recursive(child, out);
+    // Recurse into structural sub-expressions (operands of Binary, etc.).
+    match expr {
+        Expr::Binary { lhs, rhs, .. } => {
+            collect_link_ids_recursive(lhs, out);
+            collect_link_ids_recursive(rhs, out);
+        }
+        Expr::Polarity { operand, .. } => collect_link_ids_recursive(operand, out),
+        Expr::Type { lhs, .. } => collect_link_ids_recursive(lhs, out),
+        Expr::Indexer { receiver, index, .. } => {
+            collect_link_ids_recursive(receiver, out);
+            collect_link_ids_recursive(index, out);
+        }
+        Expr::Invocation { receiver, call, .. } => {
+            if let Some(r) = receiver {
+                collect_link_ids_recursive(r, out);
+            }
+            if let Invocation::Function { args, .. } = call {
+                for a in args {
+                    collect_link_ids_recursive(a, out);
+                }
+            }
+        }
+        Expr::Parenthesized { inner, .. } => collect_link_ids_recursive(inner, out),
+        Expr::Literal(_) | Expr::ExternalConstant { .. } => {}
     }
 }
 
@@ -52,16 +75,12 @@ pub(crate) fn validate_link_ids_from_expr(
     index: &QuestionnaireIndex,
     scope_link_id: Option<&str>,
 ) -> Result<Vec<Diagnostic>, crate::ParseError> {
-    let tokens = crate::lexer::tokenize(expr)?;
-    let mut parser = crate::parser::Parser::new(&tokens);
-    let typed = parser.parse_entire_expression()?;
-    let root = crate::compat::lower(&typed, &tokens);
-
-    Ok(validate_link_ids_from_ast(&root, index, scope_link_id))
+    let typed = crate::parse(expr)?;
+    Ok(validate_link_ids_from_ast(&typed, index, scope_link_id))
 }
 
 fn validate_link_ids_from_ast(
-    root: &AstNode,
+    root: &Expr,
     index: &QuestionnaireIndex,
     scope_link_id: Option<&str>,
 ) -> Vec<Diagnostic> {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -57,6 +57,22 @@ pub enum Expr {
     },
 }
 
+impl Expr {
+    /// Span covering this expression in the source.
+    pub fn span(&self) -> &Span {
+        match self {
+            Expr::Binary { span, .. }
+            | Expr::Polarity { span, .. }
+            | Expr::Type { span, .. }
+            | Expr::Indexer { span, .. }
+            | Expr::Invocation { span, .. }
+            | Expr::Parenthesized { span, .. }
+            | Expr::ExternalConstant { span, .. } => span,
+            Expr::Literal(lit) => lit.span(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum Invocation {
     Member {
@@ -78,6 +94,19 @@ pub enum Invocation {
     },
 }
 
+impl Invocation {
+    /// Span covering this invocation in the source.
+    pub fn span(&self) -> &Span {
+        match self {
+            Invocation::Member { ident } => &ident.span,
+            Invocation::Function { span, .. }
+            | Invocation::This { span }
+            | Invocation::Index { span }
+            | Invocation::Total { span } => span,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum Literal {
     Null { span: Span },
@@ -89,6 +118,21 @@ pub enum Literal {
     Time { raw: String, span: Span },
 }
 
+impl Literal {
+    /// Span covering this literal in the source.
+    pub fn span(&self) -> &Span {
+        match self {
+            Literal::Null { span }
+            | Literal::Boolean { span, .. }
+            | Literal::String { span, .. }
+            | Literal::Number { span, .. }
+            | Literal::Quantity { span, .. }
+            | Literal::DateTime { span, .. }
+            | Literal::Time { span, .. } => span,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum Unit {
     String { raw: String, span: Span },
@@ -96,10 +140,31 @@ pub enum Unit {
     PluralDateTimePrecision { word: String, span: Span },
 }
 
+impl Unit {
+    /// Span covering this unit in the source.
+    pub fn span(&self) -> &Span {
+        match self {
+            Unit::String { span, .. }
+            | Unit::DateTimePrecision { span, .. }
+            | Unit::PluralDateTimePrecision { span, .. } => span,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum ExternalConstantId {
     Identifier(Identifier),
     String { raw: String, span: Span },
+}
+
+impl ExternalConstantId {
+    /// Span covering this identifier reference in the source.
+    pub fn span(&self) -> &Span {
+        match self {
+            ExternalConstantId::Identifier(id) => &id.span,
+            ExternalConstantId::String { span, .. } => span,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -201,7 +201,7 @@ fn lower_expr(expr: &Expr, tokens: &[Token]) -> AstNode {
             wrap(span, "TermExpression", par)
         }
         Expr::Literal(lit) => {
-            let span = literal_span(lit);
+            let span = lit.span();
             let lit_node = lower_literal(lit);
             let lit_term = wrap(span, "LiteralTerm", lit_node);
             wrap(span, "TermExpression", lit_term)
@@ -250,8 +250,8 @@ fn lower_invocation(inv: &Invocation, tokens: &[Token]) -> AstNode {
         Invocation::Function { name, args, span } => {
             let mut functn_children = vec![lower_identifier(name)];
             if !args.is_empty() {
-                let first_span = expr_span(&args[0]);
-                let last_span = expr_span(args.last().unwrap());
+                let first_span = args[0].span();
+                let last_span = args.last().unwrap().span();
                 let pl_tnt: Vec<String> =
                     (0..args.len().saturating_sub(1)).map(|_| ",".to_string()).collect();
                 let pl_children: Vec<AstNode> =
@@ -424,31 +424,6 @@ fn bin_op_node_type(op: BinOp) -> &'static str {
         BinOp::Union => "UnionExpression",
         BinOp::Plus | BinOp::Minus | BinOp::Concat => "AdditiveExpression",
         BinOp::Mul | BinOp::TrueDiv | BinOp::IntDiv | BinOp::Mod => "MultiplicativeExpression",
-    }
-}
-
-fn expr_span(expr: &Expr) -> &Span {
-    match expr {
-        Expr::Binary { span, .. }
-        | Expr::Polarity { span, .. }
-        | Expr::Type { span, .. }
-        | Expr::Indexer { span, .. }
-        | Expr::Invocation { span, .. }
-        | Expr::Parenthesized { span, .. }
-        | Expr::ExternalConstant { span, .. } => span,
-        Expr::Literal(lit) => literal_span(lit),
-    }
-}
-
-fn literal_span(lit: &Literal) -> &Span {
-    match lit {
-        Literal::Null { span }
-        | Literal::Boolean { span, .. }
-        | Literal::String { span, .. }
-        | Literal::Number { span, .. }
-        | Literal::Quantity { span, .. }
-        | Literal::DateTime { span, .. }
-        | Literal::Time { span, .. } => span,
     }
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -4,7 +4,9 @@
 /// reference in `expr` with the parsed `base` AST, then serializes the
 /// result back to a valid FHIRPath string.
 
-use crate::compat::AstNode;
+use crate::ast::{
+    Expr, ExternalConstantId, Invocation, Literal, QualifiedIdentifier, TypeSpecifier, Unit,
+};
 use crate::ParseError;
 
 // ── Public API ─────────────────────────────────────────────────────────
@@ -15,198 +17,207 @@ use crate::ParseError;
 /// serialized result.  Returns `expr` unchanged when no `%context` reference
 /// exists.
 pub fn resolve_context(expr: &str, base: &str) -> Result<String, ParseError> {
-    let (expr_ast, _) = crate::parse_with_compat(expr)?;
-    let (base_ast, _) = crate::parse_with_compat(base)?;
+    let expr_ast = crate::parse(expr)?;
+    let base_ast = crate::parse(base)?;
     let resolved = resolve_context_ast(&expr_ast, &base_ast);
-    Ok(ast_to_string(&resolved))
+    Ok(expr_to_string(&resolved))
 }
 
 /// AST-level substitution: replace every `%context` node in `expr_ast` with
 /// a clone of `base_ast`.
-pub fn resolve_context_ast(expr_ast: &AstNode, base_ast: &AstNode) -> AstNode {
+pub fn resolve_context_ast(expr_ast: &Expr, base_ast: &Expr) -> Expr {
     substitute(expr_ast, "context", base_ast)
 }
 
 // ── Substitution ───────────────────────────────────────────────────────
 
-/// Recursively walk `node`, replacing any `TermExpression` that wraps
-/// `ExternalConstantTerm → ExternalConstant → Identifier(name)` with a
-/// clone of `replacement`.
-fn substitute(node: &AstNode, name: &str, replacement: &AstNode) -> AstNode {
-    if is_external_constant_term_expr(node, name) {
-        return replacement.clone();
+/// Recursively walk `expr`, replacing any `ExternalConstant` with the given
+/// constant name with a clone of `replacement`.
+fn substitute(expr: &Expr, name: &str, replacement: &Expr) -> Expr {
+    match expr {
+        Expr::ExternalConstant { ident, .. } => {
+            if external_constant_name(ident) == Some(name) {
+                replacement.clone()
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::Binary { op, lhs, rhs, span } => Expr::Binary {
+            op: *op,
+            lhs: Box::new(substitute(lhs, name, replacement)),
+            rhs: Box::new(substitute(rhs, name, replacement)),
+            span: span.clone(),
+        },
+        Expr::Polarity { op, operand, span } => Expr::Polarity {
+            op: *op,
+            operand: Box::new(substitute(operand, name, replacement)),
+            span: span.clone(),
+        },
+        Expr::Type {
+            lhs,
+            op,
+            type_spec,
+            span,
+        } => Expr::Type {
+            lhs: Box::new(substitute(lhs, name, replacement)),
+            op: *op,
+            type_spec: type_spec.clone(),
+            span: span.clone(),
+        },
+        Expr::Indexer {
+            receiver,
+            index,
+            span,
+        } => Expr::Indexer {
+            receiver: Box::new(substitute(receiver, name, replacement)),
+            index: Box::new(substitute(index, name, replacement)),
+            span: span.clone(),
+        },
+        Expr::Invocation {
+            receiver,
+            call,
+            span,
+        } => {
+            let new_receiver = receiver
+                .as_ref()
+                .map(|r| Box::new(substitute(r, name, replacement)));
+            let new_call = match call {
+                Invocation::Function {
+                    name: fname,
+                    args,
+                    span: fspan,
+                } => Invocation::Function {
+                    name: fname.clone(),
+                    args: args.iter().map(|a| substitute(a, name, replacement)).collect(),
+                    span: fspan.clone(),
+                },
+                _ => call.clone(),
+            };
+            Expr::Invocation {
+                receiver: new_receiver,
+                call: new_call,
+                span: span.clone(),
+            }
+        }
+        Expr::Parenthesized { inner, span } => Expr::Parenthesized {
+            inner: Box::new(substitute(inner, name, replacement)),
+            span: span.clone(),
+        },
+        // Literals and ExternalConstant{non-matching} are returned as-is.
+        Expr::Literal(_) => expr.clone(),
     }
-
-    let mut result = node.clone();
-    result.children = node
-        .children
-        .iter()
-        .map(|child| substitute(child, name, replacement))
-        .collect();
-    result
 }
 
-/// Check whether `node` is `TermExpression > ExternalConstantTerm >
-/// ExternalConstant > Identifier` with the given constant name.
-fn is_external_constant_term_expr(node: &AstNode, name: &str) -> bool {
-    if node.node_type != "TermExpression" {
-        return false;
+fn external_constant_name(ident: &ExternalConstantId) -> Option<&str> {
+    match ident {
+        ExternalConstantId::Identifier(id) => Some(id.raw.as_str()),
+        // ExternalConstantId::String stores the raw value INCLUDING the
+        // surrounding quotes — strip them before comparing to the bare name.
+        ExternalConstantId::String { raw, .. } => {
+            if raw.len() >= 2 {
+                Some(&raw[1..raw.len() - 1])
+            } else {
+                None
+            }
+        }
     }
-    let Some(ect) = node.children.first() else { return false };
-    if ect.node_type != "ExternalConstantTerm" {
-        return false;
-    }
-    let Some(ec) = ect.children.first() else { return false };
-    if ec.node_type != "ExternalConstant" {
-        return false;
-    }
-    let Some(ident) = ec.children.first() else { return false };
-    if ident.node_type != "Identifier" {
-        return false;
-    }
-    ident.terminal_node_text.first().map(|s| s.as_str()) == Some(name)
 }
 
-// ── AST → FHIRPath string ─────────────────────────────────────────────
+// ── Expr → FHIRPath string ────────────────────────────────────────────
 
-/// Serialize an `AstNode` back to a valid FHIRPath expression string.
-pub fn ast_to_string(node: &AstNode) -> String {
-    match node.node_type {
-        // ── Binary expressions ──────────────────────────────────────
-        "ImpliesExpression" | "OrExpression" | "AndExpression"
-        | "MembershipExpression" | "EqualityExpression"
-        | "InequalityExpression" | "UnionExpression" | "AdditiveExpression"
-        | "MultiplicativeExpression" => {
-            // children: [left, right], terminal_node_text: [operator]
-            let left = ast_to_string(&node.children[0]);
-            let right = ast_to_string(&node.children[1]);
-            let op = &node.terminal_node_text[0];
-            format!("{left} {op} {right}")
+/// Serialize an `Expr` back to a valid FHIRPath expression string.
+pub fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Binary { op, lhs, rhs, .. } => {
+            let left = expr_to_string(lhs);
+            let right = expr_to_string(rhs);
+            format!("{left} {op} {right}", op = op.keyword())
         }
-
-        // ── Type expression (is/as) ────────────────────────────────
-        "TypeExpression" => {
-            let left = ast_to_string(&node.children[0]);
-            let type_spec = ast_to_string(&node.children[1]);
-            let op = &node.terminal_node_text[0];
-            format!("{left} {op} {type_spec}")
+        Expr::Type { lhs, op, type_spec, .. } => {
+            let left = expr_to_string(lhs);
+            let ts = type_specifier_to_string(type_spec);
+            format!("{left} {op} {ts}", op = op.keyword())
         }
-
-        // ── Unary ──────────────────────────────────────────────────
-        "PolarityExpression" => {
-            let op = &node.terminal_node_text[0];
-            let operand = ast_to_string(&node.children[0]);
-            format!("{op}{operand}")
+        Expr::Polarity { op, operand, .. } => {
+            let inner = expr_to_string(operand);
+            format!("{op}{inner}", op = op.keyword())
         }
-
-        // ── Postfix ────────────────────────────────────────────────
-        "InvocationExpression" => {
-            let left = ast_to_string(&node.children[0]);
-            let right = ast_to_string(&node.children[1]);
+        Expr::Indexer { receiver, index, .. } => {
+            let r = expr_to_string(receiver);
+            let i = expr_to_string(index);
+            format!("{r}[{i}]")
+        }
+        Expr::Invocation {
+            receiver: Some(rcv),
+            call,
+            ..
+        } => {
+            let left = expr_to_string(rcv);
+            let right = invocation_to_string(call);
             format!("{left}.{right}")
         }
-
-        "IndexerExpression" => {
-            let left = ast_to_string(&node.children[0]);
-            let index = ast_to_string(&node.children[1]);
-            format!("{left}[{index}]")
+        Expr::Invocation {
+            receiver: None,
+            call,
+            ..
+        } => invocation_to_string(call),
+        Expr::Parenthesized { inner, .. } => {
+            let s = expr_to_string(inner);
+            format!("({s})")
         }
+        Expr::Literal(lit) => literal_to_string(lit),
+        Expr::ExternalConstant { ident, .. } => match ident {
+            ExternalConstantId::Identifier(id) => format!("%{}", id.raw),
+            ExternalConstantId::String { raw, .. } => format!("%{}", raw),
+        },
+    }
+}
 
-        // ── Terms (single-child wrappers) ──────────────────────────
-        "TermExpression" | "LiteralTerm" | "InvocationTerm"
-        | "ExternalConstantTerm" | "QuantityLiteral" | "TypeSpecifier" => {
-            ast_to_string(&node.children[0])
+fn invocation_to_string(inv: &Invocation) -> String {
+    match inv {
+        Invocation::Member { ident } => ident.raw.clone(),
+        Invocation::Function { name, args, .. } => {
+            let arg_strs: Vec<String> = args.iter().map(expr_to_string).collect();
+            format!("{}({})", name.raw, arg_strs.join(", "))
         }
+        Invocation::This { .. } => "$this".to_string(),
+        Invocation::Index { .. } => "$index".to_string(),
+        Invocation::Total { .. } => "$total".to_string(),
+    }
+}
 
-        // ── Parenthesized ──────────────────────────────────────────
-        "ParenthesizedTerm" => {
-            let inner = ast_to_string(&node.children[0]);
-            format!("({inner})")
-        }
-
-        // ── External constant (%name) ──────────────────────────────
-        "ExternalConstant" => {
-            let ident = ast_to_string(&node.children[0]);
-            format!("%{ident}")
-        }
-
-        // ── Invocations ────────────────────────────────────────────
-        "MemberInvocation" => ast_to_string(&node.children[0]),
-
-        "FunctionInvocation" => ast_to_string(&node.children[0]),
-
-        "Functn" => {
-            // children[0] = Identifier, children[1] = optional ParamList
-            let name = ast_to_string(&node.children[0]);
-            if node.children.len() > 1 {
-                let params = ast_to_string(&node.children[1]);
-                format!("{name}({params})")
-            } else {
-                format!("{name}()")
-            }
-        }
-
-        "ParamList" => {
-            // children = [expr, expr, ...], separated by commas
-            node.children
-                .iter()
-                .map(ast_to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        }
-
-        // ── Special invocations ────────────────────────────────────
-        "ThisInvocation" | "IndexInvocation" | "TotalInvocation" => {
-            node.terminal_node_text[0].clone()
-        }
-
-        // ── Identifier ─────────────────────────────────────────────
-        "Identifier" => node.terminal_node_text[0].clone(),
-
-        // ── Qualified identifier (for type specifiers) ─────────────
-        "QualifiedIdentifier" => {
-            node.children
-                .iter()
-                .map(ast_to_string)
-                .collect::<Vec<_>>()
-                .join(".")
-        }
-
-        // ── Literals ───────────────────────────────────────────────
-        "NullLiteral" => "{}".to_string(),
-
-        "BooleanLiteral" | "StringLiteral" | "NumberLiteral"
-        | "DateTimeLiteral" | "TimeLiteral" => {
-            node.terminal_node_text[0].clone()
-        }
-
-        // ── Quantity (number + unit) ───────────────────────────────
-        "Quantity" => {
-            let number = &node.terminal_node_text[0];
-            let unit = ast_to_string(&node.children[0]);
-            format!("{number} {unit}")
-        }
-
-        "Unit" => {
-            if !node.children.is_empty() {
-                // DateTimePrecision or PluralDateTimePrecision
-                ast_to_string(&node.children[0])
-            } else {
-                // String-literal unit (e.g. 'mg')
-                node.terminal_node_text[0].clone()
-            }
-        }
-
-        "DateTimePrecision" | "PluralDateTimePrecision" => {
-            node.terminal_node_text[0].clone()
-        }
-
-        // Fallback — shouldn't happen with a well-formed AST
-        _ => {
-            eprintln!("ast_to_string: unknown node type {:?}", node.node_type);
-            String::new()
+fn literal_to_string(lit: &Literal) -> String {
+    match lit {
+        Literal::Null { .. } => "{}".to_string(),
+        Literal::Boolean { value, .. } => if *value { "true" } else { "false" }.to_string(),
+        Literal::String { raw, .. } => raw.clone(),
+        Literal::Number { raw, .. } => raw.clone(),
+        Literal::DateTime { raw, .. } => raw.clone(),
+        Literal::Time { raw, .. } => raw.clone(),
+        Literal::Quantity { number, unit, .. } => {
+            format!("{} {}", number, unit_to_string(unit))
         }
     }
+}
+
+fn unit_to_string(unit: &Unit) -> String {
+    match unit {
+        Unit::String { raw, .. } => raw.clone(),
+        Unit::DateTimePrecision { word, .. } => word.clone(),
+        Unit::PluralDateTimePrecision { word, .. } => word.clone(),
+    }
+}
+
+fn type_specifier_to_string(ts: &TypeSpecifier) -> String {
+    qualified_identifier_to_string(&ts.qualified)
+}
+
+fn qualified_identifier_to_string(qi: &QualifiedIdentifier) -> String {
+    qi.parts
+        .iter()
+        .map(|i| i.raw.clone())
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 #[cfg(test)]
@@ -214,8 +225,8 @@ mod tests {
     use super::*;
 
     fn roundtrip(expr: &str) -> String {
-        let (ast, _) = crate::parse_with_compat(expr).unwrap();
-        ast_to_string(&ast)
+        let ast = crate::parse(expr).unwrap();
+        expr_to_string(&ast)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Migrates every internal consumer (`resolve.rs`, `analyze/*.rs`) from the legacy ANTLR-shaped `AstNode` to the typed `Expr` enum. After this PR, `AstNode` survives only as the lowering output for the Python/WASM bindings (Phase 5 collapses that). The lowering layer (`compat::lower`) is now reachable only from `lib.rs::parse_with_compat` and the two binding files.

All 184 tests (182 lib + 2 snapshot covering 91 golden + 66 synthetic FHIRPath expressions) pass byte-for-byte at every commit.

## Commits

1. **`d08a241` feat(ast): add span() accessors to typed AST types** (+68/−28). `Expr::span`, `Invocation::span`, `Literal::span`, `Unit::span`, `ExternalConstantId::span`. Removes redundant `expr_span` / `literal_span` helpers in `compat.rs`.
2. **`0fbf5c9` refactor(resolve): consume Expr directly** (+176/−165). `resolve_context_ast` and the round-trip `expr_to_string` (renamed from `ast_to_string`) now operate on `&Expr`. Public string-in/string-out `resolve_context` signature unchanged.
3. **`00fe2f0` refactor(analyze/result_type): consume Expr directly** (+213/−345). `infer_result_type`, `infer_cardinality`, and `annotate_expression_with_ast` migrate. Note the net **−132 lines** — typed matching is denser than positional `children[N]`.
4. **`2dd59b9` refactor(analyze): consume Expr directly in annotations/completions/link_ids** (+421/−381). `decompose_chain`, `extract_link_id_from_where`, `find_answer_refs`, `find_coded_values` walk `Expr` via explicit structural recursion. `validate_link_ids` and `completions` go through `crate::parse` directly.

## Consumer signature changes (all `pub(crate)` — no FFI impact)

| Function | Before → After |
|---|---|
| `resolve::resolve_context_ast` | `&AstNode, &AstNode → AstNode` → `&Expr, &Expr → Expr` |
| `resolve::ast_to_string` | renamed to `expr_to_string`; takes `&Expr` |
| `analyze::result_type::infer_result_type` | `&AstNode, …` → `&Expr, …` |
| `analyze::result_type::infer_cardinality` | `&AstNode, …` → `&Expr, …` |
| `analyze::annotations::annotate_expression_with_ast` | `→ (AstNode, …)` → `→ (Expr, …)` |
| `analyze::annotations::decompose_chain` | `&AstNode` → `&Expr` |
| `analyze::annotations::extract_link_id_from_where` | `&AstNode` (Functn) → `&[Expr]` (args) |

Public string-in/string-out APIs (`annotate_expression`, `analyze_expression`, `generate_completions`, `resolve_context`) are unchanged.

## Lowering layer reach (after this PR)

`compat::lower` and `parse_with_compat` are reachable from exactly four sites: their own definitions plus `bindings/python.rs:394` and `bindings/wasm.rs:32`. No internal consumer touches the lowered tree.

## Legacy behaviors preserved (not bugs introduced here, but flagged)

- **`validate_link_ids` no-recurse**: legacy stops at the outermost matching chain; nested `where(item.where(linkId='nested')...)` patterns silently miss `'nested'`. Preserved verbatim.
- **`find_answer_refs` skips function arguments after a chain match**: preserved.
- **String literals keep surrounding quotes** in `Literal::String::raw` and `ExternalConstantId::String::raw`; consumers strip via `[1..len-1]` in `extract_string_value` / `external_constant_name`.

## Verification

- [x] `cargo test --no-default-features` — 184 passed at every commit
- [x] `cargo check --no-default-features --features wasm` — clean
- [x] No internal `compat::lower` / `parse_with_compat` calls remain outside bindings

## What's next

- **Phase 5** — collapse `bindings/python.rs::ast_to_pydict` and `compat::lower_to_compat_json`. Either share a visitor via trait, or have `ast_to_pydict` translate `serde_json::Value → PyObject` (or use `serde-pyobject`).
- **Phase 6** — delete the lowering layer, change the Python dict shape to typed enum tags. Breaking FFI change; pair with a v4.0 release. The snapshot fixtures (which encode the legacy shape) need replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)