### PR TITLE
fix(analyze): recurse into chain-arg subtrees after outer-chain match

### DIFF
--- a/src/analyze/annotations.rs
+++ b/src/analyze/annotations.rs
@@ -712,7 +712,8 @@ fn find_answer_refs(expr: &Expr, out: &mut Vec<Annotation>, diagnostics: &mut Ve
                         kind,
                         attribution: result.attribution,
                     });
-                    return; // Don't recurse into children of a matched node
+                    recurse_into_chain_args(target, out, diagnostics);
+                    return;
                 }
                 MatchOutcome::Unattributable => {
                     diagnostics.push(Diagnostic {
@@ -723,6 +724,7 @@ fn find_answer_refs(expr: &Expr, out: &mut Vec<Annotation>, diagnostics: &mut Ve
                             "Expression navigates into a QuestionnaireResponse but cannot be attributed to a specific linkId"
                                 .to_string(),
                     });
+                    recurse_into_chain_args(target, out, diagnostics);
                     return;
                 }
                 MatchOutcome::NotApplicable => {
@@ -762,6 +764,40 @@ fn find_answer_refs(expr: &Expr, out: &mut Vec<Annotation>, diagnostics: &mut Ve
             find_answer_refs(inner, out, diagnostics);
         }
         Expr::Literal(_) | Expr::ExternalConstant { .. } => {}
+    }
+}
+
+/// Walk the chain spine, recursing into the arguments of every function call
+/// (and the index expression of every indexer). The spine itself is consumed
+/// by `decompose_chain`, so visiting it again would only re-emit the same
+/// annotation; arg subtrees are independent and may contain their own QR
+/// references.
+fn recurse_into_chain_args(
+    expr: &Expr,
+    out: &mut Vec<Annotation>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = expr;
+    loop {
+        let stripped = unwrap_parens(cursor);
+        match stripped {
+            Expr::Invocation { receiver, call, .. } => {
+                if let Invocation::Function { args, .. } = call {
+                    for a in args {
+                        find_answer_refs(a, out, diagnostics);
+                    }
+                }
+                match receiver {
+                    Some(r) => cursor = r,
+                    None => break,
+                }
+            }
+            Expr::Indexer { receiver, index, .. } => {
+                find_answer_refs(index, out, diagnostics);
+                cursor = receiver;
+            }
+            _ => break,
+        }
     }
 }
 
@@ -1395,6 +1431,35 @@ mod tests {
             .diagnostics
             .iter()
             .all(|d| d.code != DiagnosticCode::InvalidAccessorForType));
+    }
+
+    #[test]
+    fn test_nested_answer_ref_in_where_predicate_is_surfaced() {
+        // The outer chain matches as an ItemReference for 'x'; the inner
+        // chain inside the where() predicate is an AnswerReference to 'y'.
+        // Both should be surfaced — see issue #61.
+        let r = annotate_expression(
+            "item.where(linkId='x').where(item.where(linkId='y').answer.value = 'yes')",
+        )
+        .unwrap();
+        assert!(r.iter().any(|a| matches!(&a.kind, AnnotationKind::ItemReference { link_ids }
+            if link_ids == &["x"])));
+        assert!(r.iter().any(|a| matches!(&a.kind, AnnotationKind::AnswerReference { link_ids, accessor }
+            if link_ids == &["y"] && *accessor == ValueAccessor::Value)));
+    }
+
+    #[test]
+    fn test_nested_answer_ref_under_unattributable_outer() {
+        // Outer chain ends Unattributable (emits a diagnostic); the inner
+        // arg still hosts a clean answer reference and must be surfaced.
+        let (annotations, diagnostics) = annotate_expression_with_diagnostics(
+            "item.iif(linkId='x', item.where(linkId='y').answer.value, 'fallback')",
+        )
+        .unwrap();
+        assert!(annotations.iter().any(|a| matches!(&a.kind, AnnotationKind::AnswerReference { link_ids, .. }
+            if link_ids == &["y"])));
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::ExpressionNotAttributable);
     }
 
     #[test]

--- a/src/analyze/validate_link_ids.rs
+++ b/src/analyze/validate_link_ids.rs
@@ -32,11 +32,11 @@ fn collect_link_ids_recursive(expr: &Expr, out: &mut Vec<(String, Span)>) {
                     }
                 }
             }
-            // Match legacy behavior: skip recursing into children entirely
-            // after a chain match. The chain decomposition from the outermost
-            // node already captures all top-level linkIds, and inner Invocation
-            // nodes would produce duplicates. (Side effect: linkIds buried in
-            // non-linkId where-predicates aren't validated — preserved as-is.)
+            // Walk the chain spine and recurse into function arguments and
+            // indexer index expressions — those sub-trees aren't visited by
+            // `decompose_chain` and may carry their own linkId references
+            // (e.g. inside a non-linkId `where()` predicate).
+            recurse_into_chain_args(expr, out);
             return;
         }
     }
@@ -65,6 +65,37 @@ fn collect_link_ids_recursive(expr: &Expr, out: &mut Vec<(String, Span)>) {
         }
         Expr::Parenthesized { inner, .. } => collect_link_ids_recursive(inner, out),
         Expr::Literal(_) | Expr::ExternalConstant { .. } => {}
+    }
+}
+
+/// Walk the chain spine, recursing into function-call arguments and indexer
+/// index expressions. The spine itself is consumed by `decompose_chain`; arg
+/// subtrees are independent and may contain their own where(linkId=…) clauses.
+fn recurse_into_chain_args(expr: &Expr, out: &mut Vec<(String, Span)>) {
+    let mut cursor = expr;
+    loop {
+        let stripped = match cursor {
+            Expr::Parenthesized { inner, .. } => inner.as_ref(),
+            other => other,
+        };
+        match stripped {
+            Expr::Invocation { receiver, call, .. } => {
+                if let Invocation::Function { args, .. } = call {
+                    for a in args {
+                        collect_link_ids_recursive(a, out);
+                    }
+                }
+                match receiver {
+                    Some(r) => cursor = r.as_ref(),
+                    None => break,
+                }
+            }
+            Expr::Indexer { receiver, index, .. } => {
+                collect_link_ids_recursive(index, out);
+                cursor = receiver.as_ref();
+            }
+            _ => break,
+        }
     }
 }
 
@@ -229,6 +260,39 @@ mod tests {
         )
         .unwrap();
         assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_nested_link_id_in_non_link_id_where_predicate_is_validated() {
+        // The outer chain's first where() collects 'choice1'; the second
+        // where() has a non-linkId predicate that itself contains a chain
+        // referencing a bogus linkId. That nested reference must be
+        // validated — see issue #60.
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids_from_expr(
+            "item.where(linkId='choice1').answer.where(item.where(linkId='nonexistent').answer.value = 'yes')",
+            &idx,
+            None,
+        )
+        .unwrap();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::UnknownLinkId);
+        assert!(diags[0].message.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_nested_link_id_no_duplicate() {
+        // Sanity: a linkId that appears only on the spine isn't picked up
+        // twice when we also descend into args.
+        let idx = QuestionnaireIndex::build(&sample_questionnaire());
+        let diags = validate_link_ids_from_expr(
+            "item.where(linkId='nope').answer.where(value = 'x')",
+            &idx,
+            None,
+        )
+        .unwrap();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("nope"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #60 — `validate_link_ids` now validates linkIds nested inside non-linkId `where()` predicates.
- Fixes #61 — `find_answer_refs` now surfaces answer references that live inside the args of a function call on an already-matched chain.

Both walkers shared the same shape: after `decompose_chain` succeeded, they `return`ed without ever descending into the args of any function call along the spine. That dropped anything inside a `where()` / `iif()` predicate.

The fix is symmetric in both files: after handling the outer-chain outcome, walk the spine and recurse into each function's args (and any indexer's index expr). Spine nodes themselves are still only consumed by `decompose_chain`, so no duplicate annotations or linkIds are produced.

## Test plan

- [x] `cargo test --lib` — 186 pass (4 new + 182 existing)
- [x] `test_nested_answer_ref_in_where_predicate_is_surfaced` — outer ItemRef + inner AnswerRef both emitted
- [x] `test_nested_answer_ref_under_unattributable_outer` — diagnostic still emitted, inner ref still surfaced
- [x] `test_nested_link_id_in_non_link_id_where_predicate_is_validated` — `'nonexistent'` buried in a non-linkId where() now flagged
- [x] `test_nested_link_id_no_duplicate` — sanity check that spine + args walk doesn't double-count

🤖 Generated with [Claude Code](https://claude.com/claude-code)